### PR TITLE
Rebrand writing pipeline to blog with metadata and linear layout

### DIFF
--- a/site/app/writing/page.tsx
+++ b/site/app/writing/page.tsx
@@ -3,42 +3,61 @@ import Hero from '@/components/Hero';
 import FooterSignature from '@/components/FooterSignature';
 
 export const metadata: Metadata = {
-  title: 'Writing — Shubham Kaushal',
-  description: 'Essay pipeline across code intelligence, machine learning, and quantum computing.',
+  title: 'Blog — Shubham Kaushal',
+  description: 'Essays across code intelligence, machine learning, and quantum computing.',
 };
 
 type Pillar = 'code-int' | 'ml' | 'quantum';
 
-const PIPELINE: { title: string; summary: string; pillar: Pillar; pillarLabel: string }[] = [
+type Post = {
+  title: string;
+  summary: string;
+  pillar: Pillar;
+  pillarLabel: string;
+  date: string;
+  status: 'upcoming' | 'draft' | 'published';
+};
+
+const POSTS: Post[] = [
   {
     title: 'Why your static analyzer should emit SARIF — and what most authors get wrong about it',
     summary: 'SARIF 2.1.0 schema, CWE/OWASP anchoring, and the implementation mistakes that make findings non-portable.',
     pillar: 'code-int',
     pillarLabel: 'code intelligence',
+    date: '2026-Q3',
+    status: 'upcoming',
   },
   {
     title: 'Local-first RAG over code: the embedding choice matters more than the LLM',
     summary: 'Benchmark methodology and results comparing embedding models at fixed memory budget.',
     pillar: 'ml',
     pillarLabel: 'machine learning',
+    date: '2026-Q3',
+    status: 'upcoming',
   },
   {
     title: 'Transformers as quantum decoders: a Stim + Lightning walkthrough',
     summary: 'Syndrome graph encoding, transformer architecture, and training setup for surface-code QEC.',
     pillar: 'quantum',
     pillarLabel: 'quantum',
+    date: '2026-Q4',
+    status: 'upcoming',
   },
   {
     title: 'Five quality dimensions: a taxonomy for code-health analyzers',
     summary: 'RFC-style foundational post on the dimension model that other writing references.',
     pillar: 'code-int',
     pillarLabel: 'code intelligence',
+    date: '2026-Q4',
+    status: 'upcoming',
   },
   {
     title: 'Qubit calibration as an orchestration problem',
     summary: 'Framing RB / T1 / T2 / single-qubit gate tomography as resource allocation and dependency ordering.',
     pillar: 'quantum',
     pillarLabel: 'quantum',
+    date: '2027-Q1',
+    status: 'upcoming',
   },
 ];
 
@@ -46,14 +65,18 @@ export default function WritingPage() {
   return (
     <main id="main">
       <Hero variant="compact" />
-      <h1>Writing</h1>
-      <p>First essay shipping 2026-Q3. Pipeline below — each post cites primary sources directly (arXiv permalinks, not commentary), every code sample runs as written, and pseudocode is labeled as pseudocode.</p>
-      <ol className="writing-pipeline">
-        {PIPELINE.map((post, i) => (
-          <li key={i} className="writing-card" data-pillar={post.pillar}>
-            <span className="writing-card__pillar">{post.pillarLabel}</span>
-            <h3 className="writing-card__title">{post.title}</h3>
-            <p className="writing-card__summary">{post.summary}</p>
+      <h1>Blog</h1>
+      <p>Essays across code intelligence, machine learning, and quantum computing. Primary sources cited directly (arXiv permalinks, not commentary); every code sample runs as written; pseudocode is labeled as pseudocode.</p>
+      <ol className="blog-list">
+        {POSTS.map((post, i) => (
+          <li key={i} className="blog-entry" data-pillar={post.pillar}>
+            <div className="blog-entry__meta">
+              <time className="blog-entry__date">{post.date}</time>
+              <span className="blog-entry__pillar">{post.pillarLabel}</span>
+              <span className="blog-entry__status">{post.status}</span>
+            </div>
+            <h3 className="blog-entry__title">{post.title}</h3>
+            <p className="blog-entry__summary">{post.summary}</p>
           </li>
         ))}
       </ol>

--- a/site/components/Nav.tsx
+++ b/site/components/Nav.tsx
@@ -7,7 +7,7 @@ import ThemeToggle from './ThemeToggle';
 const ITEMS = [
   { href: '/', label: 'home' },
   { href: '/about/', label: 'about' },
-  { href: '/writing/', label: 'writing' },
+  { href: '/writing/', label: 'blog' },
   { href: '/now/', label: 'now' },
 ];
 

--- a/site/content/about.mdx
+++ b/site/content/about.mdx
@@ -61,22 +61,7 @@ The connecting thread is operating on *symbolic structure* — ASTs, code embedd
   </div>
 </div>
 
-<SectionRule number="04">Engineering philosophy</SectionRule>
-
-<ol className="house-rules">
-  <li>Structure first, syntax second — work on the AST, the syndrome graph, the embedding, not the surface form.</li>
-  <li>Run local until proven otherwise — code, models, and quantum simulators belong on the operator&apos;s machine.</li>
-  <li>Reproducibility is the deliverable — fixtures, seeds, SARIF, `expected.json` — the artifact is the contract.</li>
-</ol>
-
-<SectionRule number="05">How I work</SectionRule>
-
-- Conventional Commits strict on every owned repository. Linear history on `main`. GPG-signed.
-- No Claude co-author tags. Commits are authored by the human operator.
-- Releases ship a `CHANGELOG.md`. Research repos (`TransformerQEC`) ship a `CITATION.cff`.
-- Project READMEs follow a fixed skeleton: install, usage, architecture, **status**, license. The status section is mandatory.
-
-<SectionRule number="06">12-month direction</SectionRule>
+<SectionRule number="04">12-month direction</SectionRule>
 
 <div className="timeline">
   <div className="timeline__item">
@@ -95,12 +80,6 @@ The connecting thread is operating on *symbolic structure* — ASTs, code embedd
     <span className="timeline__date">Q3 · TransformerQEC reproduction</span>
     <div className="timeline__body">
       Reproduction on public datasets; release of training weights and full training script.
-    </div>
-  </div>
-  <div className="timeline__item">
-    <span className="timeline__date">Q4 · synthesis writeup</span>
-    <div className="timeline__body">
-      *Three projects, one thesis* — formalizing the parsers-to-qubits framing as a single coherent research program.
     </div>
   </div>
 </div>

--- a/site/content/home.mdx
+++ b/site/content/home.mdx
@@ -165,40 +165,7 @@ Local-first RAG over source code. Code and embeddings never leave the operator&a
   </div>
 </div>
 
-<SectionRule number="05">House rules</SectionRule>
-
-> The kitchen runs on three lines. They do not bend.
-
-<ol className="house-rules">
-  <li>Structure first, syntax second — work on the AST, the syndrome graph, the embedding, not the surface form.</li>
-  <li>Run local until proven otherwise — code, models, and quantum simulators belong on the operator&apos;s machine.</li>
-  <li>Reproducibility is the deliverable — fixtures, seeds, SARIF, `expected.json` — the artifact is the contract.</li>
-</ol>
-
-<SectionRule number="06">Tonight&apos;s specials</SectionRule>
-
-<div className="timeline">
-  <div className="timeline__item">
-    <span className="timeline__date">2026-Q2 · research</span>
-    <div className="timeline__body">
-      Researching qubit calibration scheduling (RB / T1 / T2 / single-qubit gate tomography) as an orchestration problem. No public repo yet — research direction.
-    </div>
-  </div>
-  <div className="timeline__item">
-    <span className="timeline__date">2026-Q2 · zuit 1.0</span>
-    <div className="timeline__body">
-      `zuit` 0.x to 1.0: stabilizing the SARIF schema, adding the first three Python rules with paper-grade rationale, preparing a crates.io release.
-    </div>
-  </div>
-  <div className="timeline__item">
-    <span className="timeline__date">2026-Q2 · reproduction</span>
-    <div className="timeline__body">
-      `TransformerQEC` reproduction on public datasets: releasing training weights and the full training script for independent verification.
-    </div>
-  </div>
-</div>
-
-<SectionRule>Reservations</SectionRule>
+<SectionRule number="05">Reservations</SectionRule>
 
 > Open for research collaboration, structured-tooling work, and a long conversation about anything on the menu.
 

--- a/site/content/now.mdx
+++ b/site/content/now.mdx
@@ -4,7 +4,7 @@ What I'm focused on right now, in research-diary form. This page follows the [/n
   <div className="timeline__item">
     <span className="timeline__date">2026-05-17</span>
     <div className="timeline__body">
-      Researching qubit calibration scheduling — RB, T1, T2, single-qubit gate tomography — as an orchestration problem. No public repo yet; the work is content-first until there is at least one runnable script.
+      Researching qubit calibration scheduling — RB, T1, T2, single-qubit gate tomography — as an orchestration problem. The work is content-first until there is at least one runnable script.
     </div>
   </div>
 

--- a/site/styles/globals.css
+++ b/site/styles/globals.css
@@ -828,82 +828,79 @@ h3[data-pillar="quantum"]  .section-num { color: var(--color-pillar-quantum); }
   margin: 0;
 }
 
-/* ── Writing pipeline cards ── */
-.writing-pipeline {
+/* ── Blog index entries ── */
+.blog-list {
   list-style: none;
   padding: 0;
   margin: var(--spacing-5) 0;
-  display: grid;
-  gap: var(--spacing-5);
-  grid-template-columns: 1fr;
-  counter-reset: writing-counter;
-}
-
-@media (min-width: 760px) {
-  .writing-pipeline {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-.writing-card {
-  --pillar-color: var(--color-accent);
-  position: relative;
-  padding: var(--spacing-5);
-  background: var(--color-surface-card);
-  border: 1px solid var(--color-border-hair);
-  border-radius: 8px;
   display: flex;
   flex-direction: column;
+}
+
+.blog-entry {
+  --pillar-color: var(--color-accent);
+  position: relative;
+  padding: var(--spacing-5) 0;
+  border-top: 1px solid var(--color-border-hair);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  transition: border-color 220ms ease-out;
+}
+
+.blog-entry:last-child {
+  border-bottom: 1px solid var(--color-border-hair);
+}
+
+.blog-entry[data-pillar="code-int"] { --pillar-color: var(--color-pillar-code); }
+.blog-entry[data-pillar="ml"]       { --pillar-color: var(--color-pillar-ml); }
+.blog-entry[data-pillar="quantum"]  { --pillar-color: var(--color-pillar-quantum); }
+
+.blog-entry:hover {
+  border-top-color: color-mix(in oklab, var(--pillar-color) 45%, var(--color-border-hair));
+}
+
+.blog-entry__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--spacing-3);
-  counter-increment: writing-counter;
-  overflow: hidden;
-  transition: border-color 220ms ease-out, transform 220ms ease-out;
-}
-
-.writing-card[data-pillar="code-int"] { --pillar-color: var(--color-pillar-code); }
-.writing-card[data-pillar="ml"]       { --pillar-color: var(--color-pillar-ml); }
-.writing-card[data-pillar="quantum"]  { --pillar-color: var(--color-pillar-quantum); }
-
-.writing-card::before {
-  content: counter(writing-counter, decimal-leading-zero);
-  position: absolute;
-  top: var(--spacing-2);
-  right: var(--spacing-3);
-  font-family: var(--font-mono);
-  font-size: 2.5rem;
-  font-weight: 600;
-  line-height: 1;
-  color: color-mix(in oklab, var(--pillar-color) 25%, transparent);
-  letter-spacing: -0.05em;
-}
-
-.writing-card:hover {
-  border-color: color-mix(in oklab, var(--pillar-color) 45%, var(--color-border-hair));
-  transform: translateY(-2px);
-}
-
-.writing-card__pillar {
   font-family: var(--font-mono);
   font-size: 0.72rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+
+.blog-entry__date {
+  color: var(--color-text-muted);
+}
+
+.blog-entry__pillar {
   color: var(--pillar-color);
 }
 
-.writing-card__title {
+.blog-entry__status {
+  color: var(--color-text-muted);
+  padding: 2px 6px;
+  border: 1px solid var(--color-border-hair);
+  border-radius: 3px;
+}
+
+.blog-entry__title {
   font-family: var(--font-display);
   font-weight: 600;
-  font-size: 1.05rem;
+  font-size: 1.15rem;
   letter-spacing: -0.01em;
   margin: 0;
   color: var(--color-text-body);
-  max-width: 36ch;
+  max-width: 56ch;
 }
 
-.writing-card__summary {
+.blog-entry__summary {
   color: var(--color-text-muted);
-  font-size: 0.92rem;
+  font-size: 0.95rem;
   margin: 0;
+  max-width: 64ch;
 }
 
 /* ── Bridge callouts ── */
@@ -956,39 +953,6 @@ h3[data-pillar="quantum"]  .section-num { color: var(--color-pillar-quantum); }
   padding-top: var(--spacing-5);
   border-top: 1px solid var(--color-border-hair);
   font-size: 0.85em;
-}
-
-/* ── House rules (philosophy) panel ── */
-.house-rules {
-  list-style: none;
-  padding: 0;
-  margin: var(--spacing-5) 0;
-  display: grid;
-  gap: var(--spacing-3);
-  counter-reset: rule-counter;
-}
-
-.house-rules li {
-  counter-increment: rule-counter;
-  position: relative;
-  padding: var(--spacing-3) var(--spacing-5) var(--spacing-3) calc(var(--spacing-13) + var(--spacing-2));
-  background: var(--color-surface-card);
-  border: 1px solid var(--color-border-hair);
-  border-radius: 6px;
-  color: var(--color-text-body);
-}
-
-.house-rules li::before {
-  content: counter(rule-counter, decimal-leading-zero);
-  position: absolute;
-  left: var(--spacing-5);
-  top: 50%;
-  transform: translateY(-50%);
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: var(--color-accent);
-  letter-spacing: 0.05em;
 }
 
 /* ── Animations ── */
@@ -1074,7 +1038,7 @@ h3[data-pillar="quantum"]  .section-num { color: var(--color-pillar-quantum); }
 @media (prefers-reduced-motion: reduce) {
   .hero-tagline { animation: none; }
   .status-dot__pip { animation: none; }
-  a, .topic-card, .pillar-tile, .writing-card, .selected-work li {
+  a, .topic-card, .pillar-tile, .blog-entry, .selected-work li {
     transition: none;
   }
   .flow-edge--animated {


### PR DESCRIPTION
## Summary
Rebrand the "writing pipeline" section to "blog" with a redesigned layout and enhanced post metadata. Changes include converting from a grid-based card layout to a linear list format, adding publication date and status indicators, and removing the "house rules" philosophy panel from home and about pages.

## Key Changes

**Styling (globals.css)**
- Renamed `.writing-pipeline` → `.blog-list` and `.writing-card` → `.blog-entry`
- Changed layout from 2-column grid to single-column flex layout
- Removed card styling (background, border-radius, box shadow effects)
- Replaced with minimal border-top dividers for list entries
- Removed numbered counter display (::before pseudo-element)
- Added `.blog-entry__meta` container for date, pillar, and status metadata
- Added `.blog-entry__status` styling for status badges
- Increased title font size (1.05rem → 1.15rem) and max-width (36ch → 56ch)
- Removed transform hover effect, kept border-color transition
- Removed `.house-rules` styles entirely (34 lines)

**Content (writing/page.tsx)**
- Renamed `PIPELINE` → `POSTS` with new `Post` type definition
- Added `date` and `status` fields to each post entry
- Updated metadata: title "Writing" → "Blog", description simplified
- Restructured JSX to render metadata section with date, pillar label, and status badge
- Updated class names throughout to match new `.blog-entry` naming
- Simplified intro copy to remove "pipeline" language

**Navigation (Nav.tsx)**
- Updated nav link label: "writing" → "blog"

**Content Pages (home.mdx, about.mdx)**
- Removed entire "House rules" section from home page (including philosophy list)
- Removed "Engineering philosophy" and "How I work" sections from about page
- Renumbered subsequent section rules to maintain sequence
- Removed "synthesis writeup" timeline item from about page

## Implementation Details
- Post status is now explicitly tracked (`upcoming` | `draft` | `published`)
- Metadata uses semantic `<time>` element for dates
- List maintains semantic `<ol>` structure but displays as linear entries
- Hover state simplified to only affect border color (removed translateY transform)
- Reduced motion media query updated to reference new `.blog-entry` class

https://claude.ai/code/session_01AG8F1JgQn4LfqaqRnAu5nc