### PR TITLE
Add photonics pillar with chapter-based blog post support

### DIFF
--- a/site/app/writing/page.tsx
+++ b/site/app/writing/page.tsx
@@ -4,10 +4,10 @@ import FooterSignature from '@/components/FooterSignature';
 
 export const metadata: Metadata = {
   title: 'Blog — Shubham Kaushal',
-  description: 'Essays across code intelligence, machine learning, and quantum computing.',
+  description: 'Essays and working notebooks across code intelligence, machine learning, quantum computing, and photonics.',
 };
 
-type Pillar = 'code-int' | 'ml' | 'quantum';
+type Pillar = 'code-int' | 'ml' | 'quantum' | 'photonics';
 
 type Post = {
   title: string;
@@ -16,9 +16,25 @@ type Post = {
   pillarLabel: string;
   date: string;
   status: 'upcoming' | 'draft' | 'published';
+  chapters?: string[];
 };
 
 const POSTS: Post[] = [
+  {
+    title: 'Photonics',
+    summary: 'A working notebook on photonic quantum computing — continuous-variable encoding, Gaussian operations, measurement-induced nonlinearity, and where the architecture diverges from gate-model superconducting qubits.',
+    pillar: 'photonics',
+    pillarLabel: 'photonics',
+    date: '2026-Q3',
+    status: 'upcoming',
+    chapters: [
+      'Chapter 1',
+      'Chapter 2',
+      'Chapter 3',
+      'Chapter 4',
+      'Chapter 5',
+    ],
+  },
   {
     title: 'Why your static analyzer should emit SARIF — and what most authors get wrong about it',
     summary: 'SARIF 2.1.0 schema, CWE/OWASP anchoring, and the implementation mistakes that make findings non-portable.',
@@ -66,7 +82,7 @@ export default function WritingPage() {
     <main id="main">
       <Hero variant="compact" />
       <h1>Blog</h1>
-      <p>Essays across code intelligence, machine learning, and quantum computing. Primary sources cited directly (arXiv permalinks, not commentary); every code sample runs as written; pseudocode is labeled as pseudocode.</p>
+      <p>Essays and working notebooks across code intelligence, machine learning, quantum computing, and photonics. Primary sources cited directly (arXiv permalinks, not commentary); every code sample runs as written; pseudocode is labeled as pseudocode. Multi-chapter books appear with their chapter list inline.</p>
       <ol className="blog-list">
         {POSTS.map((post, i) => (
           <li key={i} className="blog-entry" data-pillar={post.pillar}>
@@ -77,6 +93,16 @@ export default function WritingPage() {
             </div>
             <h3 className="blog-entry__title">{post.title}</h3>
             <p className="blog-entry__summary">{post.summary}</p>
+            {post.chapters && post.chapters.length > 0 && (
+              <ol className="blog-entry__chapters">
+                {post.chapters.map((chapter, j) => (
+                  <li key={j} className="blog-entry__chapter">
+                    <span className="blog-entry__chapter-num">{`[ ${String(j + 1).padStart(2, '0')} ]`}</span>
+                    <span className="blog-entry__chapter-title">{chapter}</span>
+                  </li>
+                ))}
+              </ol>
+            )}
           </li>
         ))}
       </ol>

--- a/site/scripts/verify-contrast.mjs
+++ b/site/scripts/verify-contrast.mjs
@@ -17,6 +17,7 @@ const TOKENS = {
     'pillar-code': '#7dd3fc',
     'pillar-ml': '#c4b5fd',
     'pillar-quantum': '#6ee7b7',
+    'pillar-photonics': '#fcd34d',
   },
   light: {
     'surface-base': '#fafafa',
@@ -29,6 +30,7 @@ const TOKENS = {
     'pillar-code': '#0284c7',
     'pillar-ml': '#7c3aed',
     'pillar-quantum': '#047857',
+    'pillar-photonics': '#b45309',
   },
 };
 
@@ -53,6 +55,9 @@ const PAIRS = [
   { fg: 'pillar-code',    bg: 'surface-rail', threshold: 3.0, use: 'pillar-code on rail (diagram accent)' },
   { fg: 'pillar-ml',      bg: 'surface-rail', threshold: 3.0, use: 'pillar-ml on rail (diagram accent)' },
   { fg: 'pillar-quantum', bg: 'surface-rail', threshold: 3.0, use: 'pillar-quantum on rail (diagram accent)' },
+  { fg: 'pillar-photonics', bg: 'surface-base', threshold: 3.0, use: 'pillar-photonics on page bg (blog chapter num)' },
+  { fg: 'pillar-photonics', bg: 'surface-card', threshold: 3.0, use: 'pillar-photonics on card chrome' },
+  { fg: 'pillar-photonics', bg: 'surface-rail', threshold: 3.0, use: 'pillar-photonics on rail (diagram accent)' },
 ];
 
 function hexToRgb(hex) {

--- a/site/styles/globals.css
+++ b/site/styles/globals.css
@@ -28,9 +28,10 @@
   --color-accent: #7dd3fc;
 
   /* pillar dimension family (dark default) */
-  --color-pillar-code:    #7dd3fc;  /* sky-300 */
-  --color-pillar-ml:      #c4b5fd;  /* violet-300 */
-  --color-pillar-quantum: #6ee7b7;  /* emerald-300 */
+  --color-pillar-code:      #7dd3fc;  /* sky-300 */
+  --color-pillar-ml:        #c4b5fd;  /* violet-300 */
+  --color-pillar-quantum:   #6ee7b7;  /* emerald-300 */
+  --color-pillar-photonics: #fcd34d;  /* amber-300 */
 
   /* typography */
   --font-sans: "Inter", system-ui, sans-serif;
@@ -52,9 +53,10 @@
   --color-text-footnote: #737373;
   --color-accent: #0284c7;
 
-  --color-pillar-code:    #0284c7;
-  --color-pillar-ml:      #7c3aed;
-  --color-pillar-quantum: #047857;
+  --color-pillar-code:      #0284c7;
+  --color-pillar-ml:        #7c3aed;
+  --color-pillar-quantum:   #047857;
+  --color-pillar-photonics: #b45309;
 }
 
 @layer base {
@@ -852,9 +854,10 @@ h3[data-pillar="quantum"]  .section-num { color: var(--color-pillar-quantum); }
   border-bottom: 1px solid var(--color-border-hair);
 }
 
-.blog-entry[data-pillar="code-int"] { --pillar-color: var(--color-pillar-code); }
-.blog-entry[data-pillar="ml"]       { --pillar-color: var(--color-pillar-ml); }
-.blog-entry[data-pillar="quantum"]  { --pillar-color: var(--color-pillar-quantum); }
+.blog-entry[data-pillar="code-int"]  { --pillar-color: var(--color-pillar-code); }
+.blog-entry[data-pillar="ml"]        { --pillar-color: var(--color-pillar-ml); }
+.blog-entry[data-pillar="quantum"]   { --pillar-color: var(--color-pillar-quantum); }
+.blog-entry[data-pillar="photonics"] { --pillar-color: var(--color-pillar-photonics); }
 
 .blog-entry:hover {
   border-top-color: color-mix(in oklab, var(--pillar-color) 45%, var(--color-border-hair));
@@ -901,6 +904,38 @@ h3[data-pillar="quantum"]  .section-num { color: var(--color-pillar-quantum); }
   font-size: 0.95rem;
   margin: 0;
   max-width: 64ch;
+}
+
+.blog-entry__chapters {
+  list-style: none;
+  padding: 0;
+  margin: var(--spacing-2) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  border-left: 1px solid color-mix(in oklab, var(--pillar-color) 35%, var(--color-border-hair));
+  padding-left: var(--spacing-4);
+}
+
+.blog-entry__chapter {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-3);
+  font-size: 0.9rem;
+  color: var(--color-text-body);
+}
+
+.blog-entry__chapter-num {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pillar-color);
+  min-width: 6ch;
+}
+
+.blog-entry__chapter-title {
+  color: var(--color-text-muted);
 }
 
 /* ── Bridge callouts ── */


### PR DESCRIPTION
## Summary
This PR introduces a new "photonics" content pillar to the blog and adds support for displaying multi-chapter blog posts with inline chapter listings.

## Key Changes

- **New Photonics Pillar**: Added `photonics` as a fourth content pillar alongside code intelligence, machine learning, and quantum computing
  - Defined color tokens for both dark (amber-300: `#fcd34d`) and light (amber-900: `#b45309`) themes
  - Added corresponding CSS styling for blog entries with the photonics pillar
  - Updated contrast verification script to validate photonics color accessibility

- **Chapter-Based Blog Posts**: Implemented support for multi-chapter blog posts
  - Extended `Post` type with optional `chapters` array
  - Added new CSS classes for chapter list styling (`.blog-entry__chapters`, `.blog-entry__chapter`, `.blog-entry__chapter-num`, `.blog-entry__chapter-title`)
  - Chapter numbers are formatted with zero-padding and uppercase styling, using the pillar color
  - Chapters display with a left border accent in the pillar color

- **Content Updates**:
  - Added inaugural "Photonics" post as an upcoming working notebook with 5 chapters
  - Updated blog page description to mention photonics and working notebooks
  - Updated introductory text to explain multi-chapter book formatting

- **Code Quality**: Aligned CSS variable declarations for consistency across pillar color definitions

## Implementation Details

The chapter list styling uses CSS custom properties (`--pillar-color`) to dynamically apply the appropriate pillar color to chapter numbers and borders, maintaining visual consistency with the blog entry's pillar category. The chapter numbering uses a monospace font with uppercase formatting for visual distinction.

https://claude.ai/code/session_01LSH7mK6M2Wq63ZVu2at2Tn