### PR TITLE
Add "Code intelligence" book with five chapters on tooling

### DIFF
--- a/site/app/writing/code-intelligence/[slug]/page.tsx
+++ b/site/app/writing/code-intelligence/[slug]/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import FooterSignature from '@/components/FooterSignature';
+import { CHAPTERS } from '../chapters';
+
+import Ch01 from '@/content/code-intelligence/ch01-structure-not-surface.mdx';
+import Ch02 from '@/content/code-intelligence/ch02-lexing-and-parsing.mdx';
+import Ch03 from '@/content/code-intelligence/ch03-control-flow-and-dataflow.mdx';
+import Ch04 from '@/content/code-intelligence/ch04-language-servers.mdx';
+import Ch05 from '@/content/code-intelligence/ch05-symbolic-and-neural.mdx';
+
+type ChapterComponent = (props: Record<string, unknown>) => React.ReactElement;
+
+const COMPONENTS: Record<string, ChapterComponent> = {
+  'structure-not-surface': Ch01 as ChapterComponent,
+  'lexing-and-parsing': Ch02 as ChapterComponent,
+  'control-flow-and-dataflow': Ch03 as ChapterComponent,
+  'language-servers': Ch04 as ChapterComponent,
+  'symbolic-and-neural': Ch05 as ChapterComponent,
+};
+
+export function generateStaticParams() {
+  return CHAPTERS.map((c) => ({ slug: c.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const chapter = CHAPTERS.find((c) => c.slug === slug);
+  if (chapter === undefined) return { title: 'Code intelligence — Shubham Kaushal' };
+  return {
+    title: `${chapter.title} — Code intelligence — Shubham Kaushal`,
+    description: chapter.summary,
+  };
+}
+
+export default async function CodeIntelligenceChapterPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const chapter = CHAPTERS.find((c) => c.slug === slug);
+  const Body = COMPONENTS[slug];
+  if (chapter === undefined || Body === undefined) {
+    notFound();
+  }
+
+  const index = CHAPTERS.findIndex((c) => c.slug === slug);
+  const prev = index > 0 ? CHAPTERS[index - 1] : undefined;
+  const next = index >= 0 && index < CHAPTERS.length - 1 ? CHAPTERS[index + 1] : undefined;
+
+  return (
+    <main id="main" data-pillar="code-int" className="chapter-main">
+      <p className="chapter-eyebrow">
+        <Link href="/writing/code-intelligence/">Code intelligence</Link>
+        <span aria-hidden="true"> · </span>
+        <span>{`Chapter ${chapter.number}`}</span>
+        <span aria-hidden="true"> · </span>
+        <span>{chapter.reading}</span>
+      </p>
+      <article className="chapter-article">
+        <Body />
+      </article>
+      <nav className="chapter-nav" aria-label="Chapter navigation">
+        {prev !== undefined ? (
+          <Link
+            href={`/writing/code-intelligence/${prev.slug}/`}
+            className="chapter-nav__prev"
+          >
+            <span className="chapter-nav__direction">{`← Chapter ${prev.number}`}</span>
+            <span className="chapter-nav__title">{prev.title}</span>
+          </Link>
+        ) : (
+          <span className="chapter-nav__placeholder" />
+        )}
+        {next !== undefined ? (
+          <Link
+            href={`/writing/code-intelligence/${next.slug}/`}
+            className="chapter-nav__next"
+          >
+            <span className="chapter-nav__direction">{`Chapter ${next.number} →`}</span>
+            <span className="chapter-nav__title">{next.title}</span>
+          </Link>
+        ) : (
+          <span className="chapter-nav__placeholder" />
+        )}
+      </nav>
+      <FooterSignature />
+    </main>
+  );
+}

--- a/site/app/writing/code-intelligence/chapters.ts
+++ b/site/app/writing/code-intelligence/chapters.ts
@@ -1,0 +1,50 @@
+export type Chapter = {
+  number: string;
+  slug: string;
+  title: string;
+  summary: string;
+  reading: string;
+};
+
+export const CHAPTERS: Chapter[] = [
+  {
+    number: '01',
+    slug: 'structure-not-surface',
+    title: 'Why code intelligence? Structure, not surface.',
+    summary:
+      'Working on the tree, the graph, and the symbol table beats working on the text — explained without making you read a compilers textbook first.',
+    reading: '9 min',
+  },
+  {
+    number: '02',
+    slug: 'lexing-and-parsing',
+    title: 'Lexing, parsing, and the trees you get for your trouble.',
+    summary:
+      'Bytes become tokens, tokens become a concrete tree, the concrete tree gets pruned into an abstract tree. Each step throws something away and earns something — and incremental parsing is what makes the whole thing usable in an IDE.',
+    reading: '11 min',
+  },
+  {
+    number: '03',
+    slug: 'control-flow-and-dataflow',
+    title: 'Control flow, dataflow, and what soundness costs.',
+    summary:
+      'The graph, the lattice, and the fixed point — how a static analyzer actually computes facts about your program, and why being right and being useful are in tension.',
+    reading: '12 min',
+  },
+  {
+    number: '04',
+    slug: 'language-servers',
+    title: 'The language server as an incremental cache.',
+    summary:
+      'LSP, salsa-style query systems, and the cache-invalidation problem at the heart of every modern IDE — why latency, not algorithmic correctness, is the binding constraint.',
+    reading: '12 min',
+  },
+  {
+    number: '05',
+    slug: 'symbolic-and-neural',
+    title: 'Symbolic and neural: hybrid code intelligence.',
+    summary:
+      'Embeddings over code, retrieval pipelines, and why the production system you actually want is a language server plus a vector index plus a model — wired up so each does what it is good at.',
+    reading: '13 min',
+  },
+];

--- a/site/app/writing/code-intelligence/page.tsx
+++ b/site/app/writing/code-intelligence/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Hero from '@/components/Hero';
+import FooterSignature from '@/components/FooterSignature';
+import { CHAPTERS } from './chapters';
+
+export const metadata: Metadata = {
+  title: 'Code intelligence — Shubham Kaushal',
+  description:
+    'A working notebook on code intelligence — parsers, static analysis, language servers, and the hybrid symbolic-plus-neural systems that ship in modern developer tools.',
+};
+
+export default function CodeIntelligenceBookPage() {
+  return (
+    <main id="main" data-pillar="code-int">
+      <Hero variant="compact" />
+      <p className="book-eyebrow">code intelligence · book</p>
+      <h1>Code intelligence</h1>
+      <p>
+        A working notebook on tooling that operates on structure rather than on
+        text. The tree, the graph, and the symbol table carry more than the
+        source bytes do; static analyzers, language servers, and retrieval
+        engines are different ways of asking questions over those structures.
+        The chapters develop that thesis from a small parser through a hybrid
+        symbolic-plus-neural pipeline.
+      </p>
+      <ol className="chapter-toc">
+        {CHAPTERS.map((c) => (
+          <li key={c.slug} className="chapter-toc__item">
+            <Link
+              href={`/writing/code-intelligence/${c.slug}/`}
+              className="chapter-toc__link"
+            >
+              <span className="chapter-toc__num">{`[ ${c.number} ]`}</span>
+              <span className="chapter-toc__body">
+                <span className="chapter-toc__title">{c.title}</span>
+                <span className="chapter-toc__summary">{c.summary}</span>
+                <span className="chapter-toc__reading">{c.reading}</span>
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ol>
+      <FooterSignature />
+    </main>
+  );
+}

--- a/site/app/writing/page.tsx
+++ b/site/app/writing/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import Hero from '@/components/Hero';
 import FooterSignature from '@/components/FooterSignature';
 import { CHAPTERS as PHOTONICS_CHAPTERS } from './photonics/chapters';
+import { CHAPTERS as CODE_INTELLIGENCE_CHAPTERS } from './code-intelligence/chapters';
 
 export const metadata: Metadata = {
   title: 'Blog — Shubham Kaushal',
@@ -28,6 +29,20 @@ type Post = {
 };
 
 const POSTS: Post[] = [
+  {
+    title: 'Code intelligence',
+    summary:
+      'A working notebook on tooling that operates on the tree, the graph, and the symbol table rather than on the source text — parsers, control- and data-flow analysis, language servers, and the hybrid symbolic-plus-neural systems that ship in modern developer tools.',
+    pillar: 'code-int',
+    pillarLabel: 'code intelligence',
+    date: '2026-Q2',
+    status: 'draft',
+    href: '/writing/code-intelligence/',
+    chapters: CODE_INTELLIGENCE_CHAPTERS.map((c) => ({
+      title: c.title,
+      href: `/writing/code-intelligence/${c.slug}/`,
+    })),
+  },
   {
     title: 'Photonics',
     summary: 'A working notebook on photonic quantum computing — continuous-variable encoding, Gaussian operations, measurement-induced nonlinearity, and where the architecture diverges from gate-model superconducting qubits.',

--- a/site/content/code-intelligence/ch01-structure-not-surface.mdx
+++ b/site/content/code-intelligence/ch01-structure-not-surface.mdx
@@ -1,0 +1,168 @@
+export const meta = {
+  number: '01',
+  slug: 'structure-not-surface',
+  title: 'Why code intelligence? Structure, not surface.',
+  summary: 'Working on the tree, the graph, and the symbol table beats working on the text — explained without making you read a compilers textbook first.',
+  reading: '9 min',
+};
+
+# Why code intelligence? Structure, not surface.
+
+<p className="chapter-lede">If you have ever renamed a variable with find-and-replace and shipped a bug, congratulations — you already know what this chapter is about. Source code is text on disk, but the things you actually want to do with it are not text operations. They are operations on a tree, a graph, and a symbol table. Code intelligence is the discipline of building those structures, querying them, and keeping them in sync with the text while you type.</p>
+
+## Opening intuition
+
+Picture a small everyday task. A method called `send` lives on a class in your codebase, and you want to rename it to `dispatch`. In your head, you do not think "find every occurrence of the five characters s-e-n-d." You think "find this method, and update its definition and every call site." Those are not the same operation, and the difference between them is the entire reason this book exists.
+
+A `Ctrl-F` rename will happily change `send` inside a comment that mentions the postal service, edit the string literal `"send"` that your dashboard depends on, rewrite an unrelated method `send` on a different class, and miss the dynamic call sites — `getattr(obj, name)()` in Python, `obj[methodName]()` in JavaScript — because those do not contain the literal string at all.
+
+What you wanted was a structural operation. What you got was a string operation.
+
+## The grep failure mode
+
+grep is a magnificent tool and a terrible programmer. It is fast, composable, present on every machine you will ever touch, and blind to the difference between a keyword, an identifier, a comment, and a string. To grep, the regex `\bsend\b` matches whatever it matches; the surrounding meaning is not part of the input.
+
+Concretely, four failure modes recur:
+
+1. **Over-match on substrings.** Searching for `user` finds `username`, `superuser`, and `defaultUser`. You can fight this with word boundaries until you discover that your language's notion of a word boundary disagrees with yours.
+2. **Over-match into comments and strings.** A search for the function `parse` matches the docstring sentence "we now parse the header" and the JSON key `"parse"` in a fixture file. Whether you care depends on the task. The tool cannot help you decide.
+3. **Under-match on indirection.** Python's `getattr(obj, name)()`, JavaScript's `obj[methodName]()`, Ruby's `send`, reflection-based dispatch in Java and C#, and macro-expanded names in Rust and C all hide identifiers from any text search. The reference is real; the substring is not there.
+4. **No notion of scope.** A local variable `i` in one function has nothing to do with the field `i` on a struct in another. grep cannot tell them apart because it has never heard of either.
+
+These are not edge cases. They are the median case in any codebase that has been alive long enough to grow a comment.
+
+## Analogy: street signs versus the map
+
+Suppose you are asked to find every person named Smith on Oak Street. One approach is to walk Oak Street and read the signs nailed to mailboxes. Another is to query a map that already knows which buildings are on which street and which residents live in which building. Both will, on a good day, give you the same answer. They are not the same activity.
+
+The text approach reads surface tokens in document order. The map approach traverses a graph whose nodes are buildings and whose edges are streets, and it stops when the query is satisfied. The map was expensive to build, but every query against it is cheap and exact. Reading signs is cheap to start and expensive forever.
+
+**Where the analogy breaks:**
+- A map of a city is built once and updated rarely; the structures behind code intelligence have to be rebuilt on every keystroke without blocking the editor.
+- Streets and buildings have stable identity; identifiers in code are renamed, shadowed, and re-exported, and the structure has to track those changes.
+- A real map is a single global artifact; in code, the relevant structures are per-file (the syntax tree) and per-project (the symbol table and call graph), and stitching them together is its own engineering problem.
+- Maps are queried by humans; code structures are queried mostly by other programs — language servers, linters, refactoring engines — at machine speed.
+
+## The three useful words: syntax, semantics, structure
+
+Three words get used interchangeably in casual conversation and mean different things in this book.
+
+**Syntax** is the arrangement of tokens that the language grammar admits. `if x == 0:` is syntactically valid Python; `if x = 0:` is not. The parser builds a tree, then a smaller, ruder tree. The first is the concrete syntax tree (CST) and keeps every comma, paren, and whitespace token; the second is the abstract syntax tree (AST) and throws away the punctuation the language no longer needs to interpret the code. Chapter 02 develops both.
+
+**Semantics** is what the tokens mean once they are arranged. Names resolve to declarations, expressions have types, control flows along certain paths and not others. Two programs can share syntax and disagree on semantics — `a + b` means different things if `a` is an integer, a string, or an overloaded operator on a user-defined type.
+
+**Structure** is the umbrella term for the derived artifacts that make semantic queries cheap. The symbol table maps each name use to the declaration it refers to. The call graph records, for each function, which functions it might invoke. The control-flow graph (CFG) records, within a single function, which statements can execute after which. This book revisits these three structures in every chapter; they are the load-bearing data structures of every serious code tool.
+
+The locked phrase, then, is structure first, syntax second. You parse to get a tree. You build the structures to answer questions about the tree. The tree alone is not enough.
+
+## What changes when you have structure
+
+A small comparison, with the same five tasks each tool is asked to do.
+
+<table className="encoding-table">
+  <thead>
+    <tr><th>Task</th><th>What grep does</th><th>What structural tooling does</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Rename a method</td><td>Edits every textual match, including comments and unrelated identifiers</td><td>Resolves the method to its declaration, then updates exactly the references that bind to it</td></tr>
+    <tr><td>Find references</td><td>Returns every line that contains the substring</td><td>Returns the uses that resolve to the chosen declaration, across files and modules</td></tr>
+    <tr><td>Dead-code detection</td><td>Not expressible; cannot tell a definition from a use</td><td>Walks the call graph from entry points and marks unreachable definitions</td></tr>
+    <tr><td>Trace tainted input to a sink</td><td>Not expressible; no notion of dataflow</td><td>Propagates a taint label along the dataflow graph until it reaches a sink predicate</td></tr>
+    <tr><td>Semantic autocomplete</td><td>Suggests any token it has seen before, in any file</td><td>Suggests the members of the type of the expression to the left of the dot</td></tr>
+  </tbody>
+</table>
+
+The first row is the cheap demo. The last three rows are why a thirty-year-old idea — parse the program, build a graph, query the graph — is the foundation of every static analyzer, every language server, and every code-aware AI assistant shipping today.
+
+## The pipeline, in one picture
+
+<figure className="chapter-figure">
+  <svg id="text-to-structure" viewBox="0 0 820 240" width="100%" role="img" aria-labelledby="t2s-title t2s-desc" style={{color: 'currentColor'}}>
+    <title id="t2s-title">From source text to structural representations</title>
+    <desc id="t2s-desc">A horizontal pipeline of five labelled boxes — Source, Tokens, AST, Symbols, Graphs — connected by arrows, with a one-line caption under each box describing what that stage contains.</desc>
+
+    <g fontSize="14" fill="currentColor" textAnchor="middle">
+      <g className="stage source">
+        <rect x="20" y="70" width="120" height="60" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+        <text x="80" y="105" fontWeight="600">Source</text>
+        <text x="80" y="155" fontSize="11" opacity="0.75">bytes on disk</text>
+      </g>
+
+      <line x1="140" y1="100" x2="180" y2="100" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrow)" />
+      <text x="160" y="90" fontSize="10" opacity="0.7">lex</text>
+
+      <g className="stage tokens">
+        <rect x="180" y="70" width="120" height="60" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+        <text x="240" y="105" fontWeight="600">Tokens</text>
+        <text x="240" y="155" fontSize="11" opacity="0.75">classified spans</text>
+      </g>
+
+      <line x1="300" y1="100" x2="340" y2="100" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrow)" />
+      <text x="320" y="90" fontSize="10" opacity="0.7">parse</text>
+
+      <g className="stage ast">
+        <rect x="340" y="70" width="120" height="60" fill="none" stroke="var(--pillar-color, var(--color-accent, currentColor))" strokeWidth="2" rx="4" />
+        <text x="400" y="105" fontWeight="600" fill="var(--pillar-color, var(--color-accent, currentColor))">AST</text>
+        <text x="400" y="155" fontSize="11" opacity="0.75">tree of constructs</text>
+      </g>
+
+      <line x1="460" y1="100" x2="500" y2="100" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrow)" />
+      <text x="480" y="90" fontSize="10" opacity="0.7">resolve</text>
+
+      <g className="stage symbols">
+        <rect x="500" y="70" width="120" height="60" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+        <text x="560" y="105" fontWeight="600">Symbols</text>
+        <text x="560" y="155" fontSize="11" opacity="0.75">name to declaration</text>
+      </g>
+
+      <line x1="620" y1="100" x2="660" y2="100" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrow)" />
+      <text x="640" y="90" fontSize="10" opacity="0.7">analyze</text>
+
+      <g className="stage graphs">
+        <rect x="660" y="70" width="140" height="60" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+        <text x="730" y="100" fontWeight="600">Graphs</text>
+        <text x="730" y="118" fontSize="11" opacity="0.85">call, CFG, dataflow</text>
+        <text x="730" y="155" fontSize="11" opacity="0.75">cross-procedure facts</text>
+      </g>
+    </g>
+
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>Each stage is a different representation of the same program, and each one answers questions the previous one cannot. The AST is highlighted because almost every other structure in this book is derived from it, directly or through one more pass.</figcaption>
+</figure>
+
+The pipeline is not a strict left-to-right waterfall in production tools — incremental parsers reuse old tree fragments, and language servers cache symbol tables between keystrokes — but the layers exist and the dependencies point in this direction. Chapters 02 through 04 walk each transition in detail.
+
+## What shipped tooling actually uses
+
+The pipeline is not abstract. You can name the projects that implement each stage.
+
+**Tree-sitter** is an incremental parser generator that produces concrete syntax trees for a long list of languages and re-parses only the dirty regions on each edit<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>. Every modern editor that highlights syntax accurately, including Neovim, Helix, Zed, and GitHub's web UI, runs Tree-sitter or a derivative.
+
+**Language Server Protocol** servers — rust-analyzer for Rust, gopls for Go, pyright for Python, clangd for C and C++ — own the symbol table and the type system for a project and expose them to editors over a JSON-RPC protocol<sup className="fn-ref"><a href="#fn-2">[2]</a></sup>. When you hit "go to definition" and it works across files, an LSP server resolved that name for you.
+
+**Static analyzers** sit on top of the AST and the symbol table and add their own analyses. Semgrep matches structural patterns against the AST. CodeQL treats the program as a database and lets you write queries in a Datalog-flavored language<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>. SonarQube ships a large rulebook with dataflow taint tracking. `zuit` — the author's Rust-based multi-language analyzer — emits findings as SARIF 2.1.0<sup className="fn-ref"><a href="#fn-4">[4]</a></sup>, the OASIS-standardized JSON format that lets analyzer output flow into CI, IDE, and review tooling without bespoke glue.
+
+**AI assistants** are the newest entrants. Cursor, Copilot, and Continue increasingly mix retrieval-augmented generation with structural context — pulling the type of the symbol under the cursor, the call sites of the function being edited, the imports of the current file — because pure token windows over a million-line repository miss the things a junior engineer would notice on day two. The structural representations in this book are the ones those systems are quietly building underneath.
+
+## Why this matters for the rest of the book
+
+Each subsequent chapter takes one box of the pipeline seriously.
+
+Chapter 02 covers lexing, parsing, and the CST/AST distinction, with worked examples in Tree-sitter. Chapter 03 builds the control-flow graph and the dataflow lattice and walks a small taint analysis from source to sink. Chapter 04 turns to language servers — how rust-analyzer keeps a symbol table coherent under incremental edits, and what the LSP protocol does and does not guarantee. Chapter 05 brings in embeddings and hybrid AI-plus-symbolic systems, with attention to where retrieval helps and where it quietly lies.
+
+The thesis carries through every chapter. The text is the input. The structures are the program. Build the structures, query the structures, keep the structures in sync — and the rest of code intelligence falls out as engineering on top of that contract.
+
+## Notes
+
+<ol className="footnotes">
+  <li id="fn-1">Brunsfeld, M. "Tree-sitter: an incremental parsing system for programming tools." Project documentation and source (2018–present). <a href="https://tree-sitter.github.io/tree-sitter/">https://tree-sitter.github.io/tree-sitter/</a></li>
+  <li id="fn-2">Microsoft. "Language Server Protocol Specification, version 3.17." (2022). <a href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/">https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/</a></li>
+  <li id="fn-3">Avgustinov, P., de Moor, O., Jones, M. P., and Schäfer, M. "QL: Object-oriented Queries on Relational Data." 30th European Conference on Object-Oriented Programming (ECOOP) (2016). Underpins CodeQL. <a href="https://drops.dagstuhl.de/opus/volltexte/2016/6096/">https://drops.dagstuhl.de/opus/volltexte/2016/6096/</a></li>
+  <li id="fn-4">OASIS. "Static Analysis Results Interchange Format (SARIF) Version 2.1.0." OASIS Standard (2020). <a href="https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html">https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html</a></li>
+  <li id="fn-5">Nielson, F., Nielson, H. R., and Hankin, C. "Principles of Program Analysis." Springer (1999, corrected reprint 2005). Reference text for dataflow analysis, abstract interpretation, and type-and-effect systems. <a href="https://link.springer.com/book/10.1007/978-3-662-03811-6">https://link.springer.com/book/10.1007/978-3-662-03811-6</a></li>
+</ol>

--- a/site/content/code-intelligence/ch02-lexing-and-parsing.mdx
+++ b/site/content/code-intelligence/ch02-lexing-and-parsing.mdx
@@ -1,0 +1,187 @@
+export const meta = {
+  number: '02',
+  slug: 'lexing-and-parsing',
+  title: 'Lexing, parsing, and the trees you get for your trouble.',
+  summary: 'Bytes become tokens, tokens become a concrete tree, the concrete tree gets pruned into an abstract tree. Each step throws something away and earns something — and incremental parsing is what makes the whole thing usable in an IDE.',
+  reading: '11 min',
+};
+
+# Lexing, parsing, and the trees you get for your trouble.
+
+<p className="chapter-lede">Every keystroke in a modern editor triggers the same small pipeline. Raw bytes get scanned into tokens, tokens get assembled into a tree, and the tree gets repaired in place when the user is mid-edit. The interesting design question is not "what grammar does this language use" but "what does the parser produce when the file is half-broken, and how cheaply can it produce it on the next keystroke." This chapter walks the pipeline end to end, names the trees that come out of it, and shows why incremental parsing is the only reason any of this feels instant.</p>
+
+## Lexing in plain English
+
+A lexer (also called a scanner or tokenizer) reads the source text from left to right and chops it into tokens — small labelled chunks like "the keyword `if`", "the identifier `x`", "the integer literal `42`", "the operator `==`". Whitespace and comments are usually classified as trivia: still recorded, but treated as decoration rather than structure.
+
+The mechanism is a regular language recognized by a DFA — a deterministic finite automaton, which is a tiny state machine that decides which kind of token starts at the current cursor. Lexer generators like `flex` compile a list of token patterns into one of these machines. Hand-written lexers do the same thing by reading a character, switching on it, and looping. The difference is mostly aesthetic.
+
+Take a one-line snippet.
+
+```python
+# Python 3.10+
+x = foo(42, "ok")
+```
+
+A reasonable token stream is `IDENT("x")`, `EQ`, `IDENT("foo")`, `LPAREN`, `INT(42)`, `COMMA`, `STRING("ok")`, `RPAREN`, `NEWLINE`. The lexer does not know that `foo` is a function or that `x` is a variable. It only knows the shape of the characters under the cursor. (Regex is a hammer at this layer, and yes, your config file is a nail.)
+
+## Parsing in plain English
+
+A parser takes that token stream and assembles it into a tree according to a grammar. Grammars for programming languages are usually context-free, which is a fancy way of saying the rules can nest — a parenthesized expression can contain another parenthesized expression, and the rule does not need to know how deep it is. The matching machine is a pushdown automaton, which is a finite state machine with a stack so it can remember how many open parentheses it has seen.
+
+Several algorithms implement this. LL and LR parsers read the input once and decide what rule applies based on a fixed lookahead. PEG parsers use ordered choice and unlimited backtracking. GLR and Earley parsers explore multiple interpretations in parallel and reconcile them at the end. Hand-written recursive descent is just an LL parser written out by hand, with whatever ad-hoc fixes the language needs.
+
+The choice of algorithm matters less for "what programs you can parse" than for two practical things: how well the parser recovers from a syntax error, and how cheaply it can be made incremental. Most modern shipping tooling picks an algorithm for those two reasons, not for theoretical expressiveness.
+
+## Analogy: barcode scanner and the shipping manifest
+
+Imagine a warehouse conveyor. A barcode scanner reads each item as it passes — book, book, mug, cable, cable, mug — and emits a flat stream of scans. That is lexing. Downstream, a clerk takes the stream of scans and assembles it into a shipping manifest: this box contains two books and a mug, that pallet contains four cables. The structure (boxes, pallets, the order they nest in) is built from the same flat stream the scanner produced. That is parsing.
+
+**Where the analogy breaks:**
+- The scanner does not know about boxes; the clerk does. The lexer is similarly ignorant of grammar, and a token that looks fine in isolation can still be illegal where the parser finds it.
+- The clerk can refuse a malformed manifest. An IDE parser cannot — it has to produce a useful tree even when the manifest is half-written.
+- A barcode is unambiguous. Real languages have lexer hacks: `>>` in C++ templates is one token or two depending on context, and that decision leaks information backwards from the parser.
+- Scans are independent. Tokens are not — what `if` means in Rust depends on whether it appears as a statement or as part of `if let`.
+
+## CST vs AST
+
+The parser produces a tree. There are two flavours worth distinguishing. A CST — a concrete syntax tree — keeps every token, including the trivia: whitespace, comments, the trailing comma you left in by accident. An AST — an abstract syntax tree — drops what is not semantically meaningful. A `(x + y)` and `x + y` parse to the same AST but to different CSTs, because the parentheses are real characters and the CST remembers them.
+
+Compilers historically went straight to an AST. The reasoning was reasonable: the optimiser does not care about your comments. But the same reasoning is wrong for an IDE. An IDE needs to round-trip the file — format it, refactor it, present diagnostics on specific characters — and you cannot do that if you have thrown the characters away. The CST keeps every comma you wrote, including the ones you regret.
+
+The other reason IDEs prefer CSTs is error tolerance. Between two keystrokes, the file is almost always partially broken. A CST-first parser is built to produce a tree on broken input, marking the broken regions with error nodes rather than refusing to return.
+
+## A small worked example
+
+A five-line Python function and the CST shape a tree-sitter-style parser produces for it.
+
+```python
+# Python 3.10+, parsed by tree-sitter-python
+def add(a, b):
+    """Sum two numbers."""
+    return a + b
+```
+
+A trimmed bracketed view of the CST looks like:
+
+```
+(module
+  (function_definition
+    name: (identifier "add")
+    parameters: (parameters (identifier "a") (identifier "b"))
+    body: (block
+      (expression_statement (string "\"\"\"Sum two numbers.\"\"\""))
+      (return_statement (binary_operator
+        left: (identifier "a")
+        operator: "+"
+        right: (identifier "b"))))))
+```
+
+The AST drops the docstring node's quotes, the colon after the parameter list, and the newline trivia between statements. The CST keeps them, because a refactoring tool that renames `a` to `alpha` needs to know exactly where `a` sits in the byte buffer to splice the new name in.
+
+## Parsing styles in shipping tooling
+
+Five styles cover almost all production parsers. They differ less in what they accept than in how they fail and how they update.
+
+<table className="encoding-table">
+  <thead>
+    <tr><th>Style</th><th>Used by</th><th>Strength</th><th>Weakness</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Hand-written recursive descent</td><td>rustc, clang, the TypeScript compiler</td><td>Total control over error messages and recovery; easy to special-case</td><td>Verbose; the grammar lives implicitly in the code rather than in a spec</td></tr>
+    <tr><td>LR / LALR generators</td><td>Yacc, Bison, LALRPOP, OCaml's Menhir</td><td>Compact grammar files; well-understood theory; linear time</td><td>Error recovery is awkward; ambiguity is rejected statically rather than negotiated</td></tr>
+    <tr><td>PEG</td><td>pest, Python 3.9+ via PEP 617<sup className="fn-ref"><a href="#fn-2">[2]</a></sup></td><td>Grammar reads like a hand-written parser; ordered choice removes ambiguity by fiat</td><td>Unlimited backtracking can hide performance cliffs; left-recursion needs special handling</td></tr>
+    <tr><td>GLR / Earley</td><td>tree-sitter<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>, Bison's GLR mode</td><td>Handles ambiguous and context-sensitive languages; naturally incremental</td><td>Worst-case cubic time; grammars must still be carefully written to stay near-linear in practice</td></tr>
+    <tr><td>Parser combinators</td><td>nom (Rust), megaparsec (Haskell)</td><td>Composable; the grammar is library code, so the host language's tools apply</td><td>Error messages and performance are the library's problem, and the library does not always solve them</td></tr>
+  </tbody>
+</table>
+
+The pattern across the table is the same: the more friendly the algorithm is to error recovery, the more it gives up on static guarantees about ambiguity.
+
+<figure className="chapter-figure">
+  <svg id="lex-parse-pipeline" viewBox="0 0 880 280" width="100%" role="img" aria-labelledby="lpp-title lpp-desc" style={{color: 'currentColor'}}>
+    <title id="lpp-title">The lex-parse pipeline: bytes to tokens to CST to AST</title>
+    <desc id="lpp-desc">A left-to-right pipeline with four stages. Bytes are scanned into a token stream by the lexer. Tokens are assembled into a concrete syntax tree by the parser. The concrete syntax tree is reduced to an abstract syntax tree by dropping trivia. An arrow labelled "trivia dropped" highlights the last transition.</desc>
+
+    <g className="stage stage-bytes">
+      <rect x="20" y="90" width="150" height="80" rx="8" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <text x="95" y="125" textAnchor="middle" fontSize="16" fill="currentColor" fontWeight="600">Bytes</text>
+      <text x="95" y="148" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">UTF-8 source</text>
+      <text x="95" y="195" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">"def add(a, b):"</text>
+    </g>
+
+    <line x1="170" y1="130" x2="220" y2="130" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrow)" />
+    <text x="195" y="118" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">lexer</text>
+
+    <g className="stage stage-tokens">
+      <rect x="220" y="90" width="170" height="80" rx="8" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <text x="305" y="125" textAnchor="middle" fontSize="16" fill="currentColor" fontWeight="600">Tokens</text>
+      <text x="305" y="148" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">flat stream</text>
+      <text x="305" y="195" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">DEF IDENT LPAREN ...</text>
+    </g>
+
+    <line x1="390" y1="130" x2="440" y2="130" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrow)" />
+    <text x="415" y="118" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">parser</text>
+
+    <g className="stage stage-cst">
+      <rect x="440" y="90" width="170" height="80" rx="8" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <text x="525" y="125" textAnchor="middle" fontSize="16" fill="currentColor" fontWeight="600">CST</text>
+      <text x="525" y="148" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">trivia preserved</text>
+      <text x="525" y="195" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">every comma, every space</text>
+    </g>
+
+    <g className="accent-edge">
+      <line x1="610" y1="130" x2="660" y2="130" stroke="var(--pillar-color, var(--color-accent, currentColor))" strokeWidth="3" markerEnd="url(#arrow-accent)" />
+      <text x="635" y="118" textAnchor="middle" fontSize="11" fill="var(--pillar-color, var(--color-accent, currentColor))">trivia dropped</text>
+    </g>
+
+    <g className="stage stage-ast">
+      <rect x="660" y="90" width="200" height="80" rx="8" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <text x="760" y="125" textAnchor="middle" fontSize="16" fill="currentColor" fontWeight="600">AST</text>
+      <text x="760" y="148" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">semantic skeleton</text>
+      <text x="760" y="195" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">what the compiler sees</text>
+    </g>
+
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M0,0 L10,5 L0,10 z" fill="currentColor" />
+      </marker>
+      <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M0,0 L10,5 L0,10 z" fill="var(--pillar-color, var(--color-accent, currentColor))" />
+      </marker>
+    </defs>
+
+    <text x="440" y="50" textAnchor="middle" fontSize="12" fill="currentColor" opacity="0.7">each stage throws something away and earns something</text>
+  </svg>
+  <figcaption>The pipeline reads left to right on every keystroke in an IDE. The lexer collapses byte offsets into typed tokens. The parser assembles a CST that preserves trivia and tolerates broken input. A later pass produces the AST by dropping trivia and merging syntactic sugar; that is the tree most compiler back-ends consume.</figcaption>
+</figure>
+
+## Incremental parsing and error recovery
+
+If you re-parsed the whole file on every keystroke, a 100k-line file would not feel like an IDE. Incremental parsers avoid that by keeping the previous tree, finding the smallest subtree that contains the user's edit, re-parsing only that region, and splicing the new subtree back in. Tree-sitter does this in time proportional to the size of the edit, not the size of the file<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>. Roslyn, the C# compiler-as-service, does the same with a different data structure (immutable red-green trees) and the same effect: edits are cheap because the unchanged parts of the tree are shared with the previous version<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>.
+
+Error recovery is the other half. A parser confronted with a syntax error has two reasonable choices: insert a synthetic token to satisfy the next rule, or skip tokens until it reaches a known resynchronization point such as a semicolon or a closing brace. Both leave the resulting tree marked with error nodes, which downstream tooling can ignore or surface as diagnostics. Hand-written parsers usually pick recovery strategies per construct; generated parsers usually accept a default and live with it.
+
+The combined effect is that the parser will accept things your team lead would not. That is by design. Chapter 04 picks this up: a language server is essentially a long-lived cache keyed on the tree that the parser produced, and that cache is only useful if the parser produces something even when the file is mid-edit.
+
+## What shipped tooling actually uses
+
+Concrete examples ground the discussion. Tree-sitter ships grammars for roughly 200 languages and powers GitHub's code navigation, neovim's structural highlighting, and Atom's original syntax engine; it is a GLR-style incremental parser with a custom conflict resolution scheme<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>. rust-analyzer uses a hand-written incremental parser that produces a Rowan CST, which is a Rust port of the Roslyn red-green tree design. Roslyn itself, released by Microsoft in 2014, was the first widely-deployed CST-first compiler-as-service and remains the template most other IDE backends imitate<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>.
+
+CPython switched from an LL(1) parser to a PEG parser in version 3.9, as specified in PEP 617<sup className="fn-ref"><a href="#fn-2">[2]</a></sup>. The motivation was not speed but expressiveness: the old grammar had accumulated workarounds, and a PEG let the maintainers describe Python's syntax in something close to the language reference. LALRPOP<sup className="fn-ref"><a href="#fn-5">[5]</a></sup> is the LR(1) generator most often reached for in the Rust ecosystem when a hand-written parser is overkill. GLR's theoretical foundations trace back to Tomita's 1985 work on natural-language parsing<sup className="fn-ref"><a href="#fn-4">[4]</a></sup>.
+
+## Why this matters for the rest of the book
+
+The tree is the substrate for everything downstream. Chapter 03 builds the control-flow graph and the dataflow lattice on top of an AST or IR derived from it, and the precision of those analyses bottoms out at how faithfully the parser captured the user's intent. Chapter 04 treats the language server as a cache layered on top of the parser; the cache's invalidation story is exactly the incremental-parsing story above. Chapter 05 asks whether code embeddings should be computed over the raw text, over token sequences, or over AST nodes — and the answer turns on what the parser preserves and what it discards.
+
+Each stage in the pipeline throws something away. The art is choosing what to throw away, and when.
+
+## Notes
+
+<ol className="footnotes">
+  <li id="fn-1">Brunsfeld, M. "Tree-sitter: a new parsing system for programming tools." Strange Loop 2018, and the project documentation. <a href="https://tree-sitter.github.io/tree-sitter/">https://tree-sitter.github.io/tree-sitter/</a></li>
+  <li id="fn-2">van Rossum, G., de Bondt, P., and Shannon, L. "PEP 617 – New PEG parser for CPython." Accepted 2020; shipped in CPython 3.9. <a href="https://peps.python.org/pep-0617/">https://peps.python.org/pep-0617/</a></li>
+  <li id="fn-3">Microsoft. ".NET Compiler Platform ('Roslyn')." Project repository, including the red-green tree design notes. <a href="https://github.com/dotnet/roslyn">https://github.com/dotnet/roslyn</a></li>
+  <li id="fn-4">Tomita, M. "Efficient Parsing for Natural Language: A Fast Algorithm for Practical Systems." Kluwer Academic Publishers, 1985. The original GLR formulation. <a href="https://link.springer.com/book/10.1007/978-1-4757-1885-0">https://link.springer.com/book/10.1007/978-1-4757-1885-0</a></li>
+  <li id="fn-5">Matsakis, N. et al. "LALRPOP: an LR(1) parser generator for Rust." Project repository and book. <a href="https://github.com/lalrpop/lalrpop">https://github.com/lalrpop/lalrpop</a></li>
+</ol>

--- a/site/content/code-intelligence/ch03-control-flow-and-dataflow.mdx
+++ b/site/content/code-intelligence/ch03-control-flow-and-dataflow.mdx
@@ -1,0 +1,184 @@
+export const meta = {
+  number: '03',
+  slug: 'control-flow-and-dataflow',
+  title: 'Control flow, dataflow, and what soundness costs.',
+  summary: 'The graph, the lattice, and the fixed point — how a static analyzer actually computes facts about your program, and why being right and being useful are in tension.',
+  reading: '12 min',
+};
+
+# Control flow, dataflow, and what soundness costs.
+
+<p className="chapter-lede">Every static analyzer you have ever used — the one that flags an unused variable, the one that warns about a possibly-null dereference, the one that screams about untrusted input flowing into a SQL string — is doing roughly the same thing under the hood. It builds a flowchart of your code, it carries a small set of facts along each edge, and it keeps updating those facts until they stop changing. The interesting question is not whether to do this. It is which facts to track, how precisely to track them, and which lies to tell when precision gets expensive.</p>
+
+## Opening intuition
+
+Consider three warnings a Python user sees in a normal week. "Local variable `x` is assigned but never used." "Variable `name` may be `None` at this point." "Untrusted data from `request.args` flows into `subprocess.run`." Three different tools, three different vocabularies, and yet the underlying machinery is almost identical. Each tool walks your program, attaches a set of facts to every line, and propagates those facts along the edges of a graph that represents possible executions.
+
+The facts differ. Reaching definitions, nullability, taint — they are all *sets that change as control flow advances*. The same algorithm answers all three.
+
+This chapter is about that algorithm and the trade-offs it forces. The formalism has a name (monotone dataflow analysis), an origin (Kildall 1973<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>), and a polite fiction that holds it together (most production tools are deliberately unsound, and they are right to be).
+
+## CFG — the flowchart
+
+A **CFG**, or control-flow graph, is a flowchart of your program's branches and loops. Nodes are *basic blocks* — a run of straight-line code with one way in and one way out — and edges are the possible transfers of control between them. An `if` becomes a node with two outgoing edges. A `while` becomes a node with a back-edge that loops to itself. A `switch` is a fan-out. A `try/except` adds an exception edge from every statement that could throw to the matching handler.
+
+That last one is where most analyzers quietly under-approximate. Modeling every statement as potentially throwing makes the graph enormous, so tools draw exception edges only at calls, or only at marked operations, or not at all. The analyzer is going to be wrong about exceptions; the only question is which way.
+
+Once the CFG exists, the rest of static analysis is *labeling its edges with sets of facts*.
+
+## Analogy: water through a pipe network
+
+Picture a network of pipes laid out as a flowchart. Water enters at the top, flows downward, splits at every branch, and recombines at every junction. Each pipe carries a small bucket of coloured tokens — these are the *facts* the analyzer is tracking. When a pipe runs through a basic block, the block can add tokens, remove tokens, or recolour them. When two pipes meet at a junction, the operator decides how their buckets combine: sometimes by taking the union of tokens (a *may* analysis), sometimes the intersection (a *must* analysis).
+
+Keep running the water until the buckets stop changing. That is the fixed point.
+
+**Where the analogy breaks:**
+- Water flows forward, but some dataflow analyses (like live variables) flow *backward* through the CFG. The pipes do not care which direction you choose.
+- Loops mean the same pipe is traversed many times; the bucket at a node depends on its own future contents until the iteration settles.
+- The "operator at the junction" is not a free choice — the join must be monotone with respect to the lattice or the iteration will not terminate.
+- Real programs have indirect calls and dynamic dispatch, which is the equivalent of pipes whose destination is decided by the tokens currently inside them. Most tools draw a conservative super-graph and accept the imprecision.
+
+## Dataflow: facts at every program point
+
+At each point in the program we want to know something specific. "Which definitions of which variables could reach this line?" "Which variables read below are written above?" "Which expressions have already been computed on every path here?" The analyzer carries a set of such facts, updates it as control flow advances, and merges sets when two control-flow paths meet.
+
+The formalism is small. The *lattice* ⟨L, ⊑⟩ is the space of possible fact-sets ordered by "more conservative" — bigger sets usually mean less is known. A *transfer function* `f_B : L → L` describes what one basic block `B` does to a fact-set as control passes through it. The *join operator* ⊔ is the rule for merging fact-sets at a branch join, typically set union or intersection. The analysis is *forward* if facts flow with control, *backward* if they flow against it.
+
+We then iterate. Start with an initial fact-set, apply the transfer functions, join at every confluence, and repeat. If the transfer functions are monotone and the lattice has finite height, this fixed-point iteration converges in roughly `O(nodes × height)` steps — the Kildall / Kam–Ullman bound<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>. The math is older than most languages it now analyzes, and it has not been improved upon for the general case.
+
+Rice's theorem says you cannot have it all, and Rice was right. The lattice is how we choose what to give up.
+
+## A small worked example
+
+```python
+# Python 3.11. Forward reaching-definitions analysis.
+# A "definition" is a (variable, line) pair.
+def f(flag):
+    x = 1              # d1: (x, line 4)
+    if flag:
+        x = 2          # d2: (x, line 6)
+    # program point P1: just before the join
+    y = x + 1          # d3: (y, line 8)
+    return y
+```
+
+Reaching definitions is a **forward, may** analysis. The join operator is **set union**: a definition reaches a point if it reaches along *any* incoming path.
+
+At the entry to line 6 the fact-set is `{d1}`. After line 6, the assignment `x = 2` kills `d1` (since `d1` also defines `x`) and generates `d2`, leaving `{d2}`. Along the else branch the fact-set is unchanged at `{d1}`. At program point P1, the join takes the union: `{d1, d2}` — both definitions of `x` could reach line 8. The analyzer therefore knows that `x` on line 8 has two possible sources, which is exactly the input a constant-propagation pass needs to decide it cannot replace `x` with a literal.
+
+Notice what the analyzer does *not* track. It does not know that `d1` only reaches P1 when `flag` is false. Encoding that fact would require path-sensitivity, and path-sensitivity is expensive.
+
+## Common analyses
+
+Five dataflow analyses cover most of what shipped linters compute. Each picks a direction, a join, and a lattice.
+
+<table className="encoding-table">
+  <thead>
+    <tr><th>Analysis</th><th>Direction</th><th>Join</th><th>Typical use</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Reaching definitions (may)</td><td>Forward</td><td>Union</td><td>Use-def chains, constant propagation, SSA construction</td></tr>
+    <tr><td>Live variables (may)</td><td>Backward</td><td>Union</td><td>Dead-store elimination, register allocation, "unused variable" warnings</td></tr>
+    <tr><td>Available expressions (must)</td><td>Forward</td><td>Intersection</td><td>Common subexpression elimination</td></tr>
+    <tr><td>Constant propagation</td><td>Forward</td><td>Meet on constant lattice</td><td>Folding literals, dead-branch detection</td></tr>
+    <tr><td>Taint analysis (may)</td><td>Forward</td><td>Union</td><td>Injection bugs, SSRF, secrets in logs</td></tr>
+  </tbody>
+</table>
+
+"May" analyses tell you something *might* happen along some path. "Must" analyses tell you something happens along *every* path. The choice of join is exactly the choice between those two questions.
+
+<figure className="chapter-figure">
+  <svg id="cfg-dataflow" viewBox="0 0 800 420" width="100%" role="img" aria-labelledby="cfg-title cfg-desc" style={{color: 'currentColor'}}>
+    <title id="cfg-title">A small control-flow graph with a branch, a join, and a loop back-edge</title>
+    <desc id="cfg-desc">Six basic blocks arranged top to bottom. An entry block branches into two parallel blocks, which merge at a join block. The join block flows into a loop body that contains a back-edge to itself, and finally exits.</desc>
+
+    <g className="nodes" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <rect x="330" y="20" width="140" height="46" rx="6" />
+      <rect x="330" y="110" width="140" height="46" rx="6" />
+      <rect x="170" y="195" width="140" height="46" rx="6" />
+      <rect x="490" y="195" width="140" height="46" rx="6" />
+      <rect x="330" y="280" width="140" height="46" rx="6" />
+      <rect x="330" y="360" width="140" height="46" rx="6" />
+    </g>
+
+    <g fontSize="13" fill="currentColor" textAnchor="middle" fontFamily="ui-monospace, SFMono-Regular, monospace">
+      <text x="400" y="48">entry</text>
+      <text x="400" y="138">if flag</text>
+      <text x="240" y="223">x = 2</text>
+      <text x="560" y="223">x = 1</text>
+      <text x="400" y="307">join</text>
+      <text x="400" y="388">y = x + 1; return</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.5" fill="none">
+      <line x1="400" y1="66" x2="400" y2="108" />
+      <line x1="370" y1="156" x2="270" y2="193" />
+      <line x1="430" y1="156" x2="530" y2="193" />
+      <line x1="270" y1="241" x2="370" y2="278" />
+      <line x1="530" y1="241" x2="430" y2="278" />
+      <line x1="400" y1="358" x2="400" y2="332" />
+      <path d="M 470 303 C 560 303, 560 245, 530 230" />
+    </g>
+
+    <g className="accent-edge" stroke="var(--pillar-color, var(--color-accent, currentColor))" strokeWidth="3" fill="none">
+      <line x1="270" y1="241" x2="370" y2="278" />
+    </g>
+
+    <g fontSize="11" fill="currentColor" fontFamily="ui-monospace, SFMono-Regular, monospace" opacity="0.85">
+      <text x="120" y="270">IN  = {`{d1}`}</text>
+      <text x="120" y="285">OUT = {`{d2}`}</text>
+      <text x="640" y="270">IN  = {`{d1}`}</text>
+      <text x="640" y="285">OUT = {`{d1}`}</text>
+      <text x="490" y="307" textAnchor="start" opacity="0.8">  IN = {`{d1, d2}`}</text>
+    </g>
+  </svg>
+  <figcaption>A toy CFG. Two assignments to <code>x</code> reach the join block along different paths; the join takes the union, so the entry to the next block holds both definitions. The highlighted edge is one of the two join edges where dataflow facts merge.</figcaption>
+</figure>
+
+## Path-sensitivity, context-sensitivity, and the cost
+
+The dataflow framework above is *flow-sensitive* — it respects the order of statements — but *path-insensitive*, meaning it joins facts from all paths into a branch into a single fact-set. A **path-sensitive** analysis tracks facts separately along each path, so it can keep "if `flag` is true then `x = 2`" as a single correlated fact instead of conservatively merging. A **context-sensitive** analysis, often called k-CFA after Shivers's dissertation<sup className="fn-ref"><a href="#fn-6">[6]</a></sup>, distinguishes facts at each call site rather than merging them at the function entry.
+
+Both are more precise. Both blow up exponentially in the worst case. A program with `n` branches has up to `2^n` paths; a program with `n` call sites has up to `k^n` contexts at k-CFA depth `k`.
+
+Production tools pick different points on this spectrum. CodeQL gives you a relational query language and lets you decide how much sensitivity to pay for. Infer is path-sensitive via separation logic but aggressively summarizes procedures so the cost stays sub-quadratic. Semgrep is largely pattern-based with only shallow dataflow, which is why it is fast enough to run in CI on every push. Every linter you have ever cursed is making an honest trade-off.
+
+## Soundness vs precision: the engineering choice
+
+Two words do most of the work here. An analyzer is **sound** for a property if it never misses a real instance — no false negatives. It is **complete** if it never reports a non-instance — no false positives. Rice's theorem guarantees that for any nontrivial semantic property on a Turing-complete language, you cannot have both.
+
+Most production analyzers ship deliberately unsound. ESLint and Sonar lose precision in exchange for fewer false positives, because false positives are what users complain about. The author's own `zuit` follows the same convention — it would rather miss a corner case than ship a warning that ten thousand engineers will train themselves to ignore. Infer and Astrée make the other choice: they accept more false positives so that, on the slice of properties they care about, they miss nothing<sup className="fn-ref"><a href="#fn-4">[4]</a></sup>.
+
+Neither tradition is wrong. They are answering different questions.
+
+## What shipped tooling actually uses
+
+Most production analyzers are instantiations of *abstract interpretation*, the unifying framework Cousot and Cousot published in 1977<sup className="fn-ref"><a href="#fn-2">[2]</a></sup>. The recipe: pick an abstract domain (an over-approximation of concrete values), define monotone abstract transfer functions, iterate to a fixed point in the abstract domain, and read off the soundness guarantee for free.
+
+The lanes worth knowing:
+
+- **LLVM** ships a reusable dataflow analysis framework that backs most C, C++, and Rust optimization passes; the same framework powers Clang Static Analyzer.
+- **Soot** has been the Java IR and dataflow workbench since the early 2000s and is still where most academic Java analyses prototype<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>.
+- **Facebook Infer** uses separation logic with bi-abduction to infer procedure summaries, which is how it scales to monorepos without losing path-sensitivity<sup className="fn-ref"><a href="#fn-4">[4]</a></sup>.
+- **GitHub CodeQL** models the program as a relational database and queries it in a Datalog-style language; sensitivity is something you opt into per query<sup className="fn-ref"><a href="#fn-5">[5]</a></sup>.
+- **Semgrep** is pattern matching with limited intraprocedural dataflow, optimized for speed-of-feedback in CI.
+- **`zuit`** is the author's multi-language Rust analyzer that emits SARIF 2.1.0; it sits in the same trade-off space as Semgrep but extends to taint and constant-propagation passes per language.
+
+Different domains, same skeleton: CFG, lattice, transfer functions, fixed point.
+
+## Why this matters for the rest of the book
+
+Chapter 04 takes this machinery into the editor. An IDE cannot rerun a whole-program dataflow analysis every keystroke, so it must run a *useful subset* incrementally — recomputing only the facts that could have changed inside the edited function, reusing summaries everywhere else. The incremental story is what distinguishes a usable language server from a slow one.
+
+Chapter 05 then asks what changes when an LLM enters the picture. LLM "reasoning" is a probabilistic substitute for the deterministic facts above: it will sometimes get nullability right by pattern, and sometimes wrong by hallucination. Hybrid systems combine both — the dataflow result is ground truth where it exists, and the model fills in where the analyzer punts.
+
+## Notes
+
+<ol className="footnotes">
+  <li id="fn-1">Kildall, G. A. "A unified approach to global program optimization." POPL 1973. <a href="https://doi.org/10.1145/512927.512945">https://doi.org/10.1145/512927.512945</a></li>
+  <li id="fn-2">Cousot, P. and Cousot, R. "Abstract interpretation: a unified lattice model for static analysis of programs by construction or approximation of fixpoints." POPL 1977. <a href="https://doi.org/10.1145/512950.512973">https://doi.org/10.1145/512950.512973</a></li>
+  <li id="fn-3">Nielson, F., Nielson, H. R., and Hankin, C. "Principles of Program Analysis." Springer, corrected 2nd printing 2005. <a href="https://link.springer.com/book/10.1007/978-3-662-03811-6">https://link.springer.com/book/10.1007/978-3-662-03811-6</a></li>
+  <li id="fn-4">Calcagno, C., Distefano, D., O'Hearn, P. W., and Yang, H. "Moving Fast with Software Verification." NASA Formal Methods 2015. Facebook Infer. <a href="https://research.facebook.com/publications/moving-fast-with-software-verification/">https://research.facebook.com/publications/moving-fast-with-software-verification/</a></li>
+  <li id="fn-5">Avgustinov, P., de Moor, O., Jones, M. P., and Schäfer, M. "QL: Object-oriented Queries on Relational Data." ECOOP 2016. CodeQL antecedent. <a href="https://doi.org/10.4230/LIPIcs.ECOOP.2016.2">https://doi.org/10.4230/LIPIcs.ECOOP.2016.2</a></li>
+  <li id="fn-6">Shivers, O. "Control-Flow Analysis of Higher-Order Languages." PhD dissertation, CMU 1991. Origin of k-CFA. <a href="https://www.ccs.neu.edu/home/shivers/papers/diss.pdf">https://www.ccs.neu.edu/home/shivers/papers/diss.pdf</a></li>
+</ol>

--- a/site/content/code-intelligence/ch04-language-servers.mdx
+++ b/site/content/code-intelligence/ch04-language-servers.mdx
@@ -1,0 +1,199 @@
+export const meta = {
+  number: '04',
+  slug: 'language-servers',
+  title: 'The language server as an incremental cache.',
+  summary: 'LSP, salsa-style query systems, and the cache-invalidation problem at the heart of every modern IDE — why latency, not algorithmic correctness, is the binding constraint.',
+  reading: '12 min',
+};
+
+# The language server as an incremental cache.
+
+<p className="chapter-lede">A modern IDE has to answer hard questions about a program on every keystroke, against codebases with tens of thousands of files and millions of lines, in under a hundred milliseconds. Recomputing from scratch is not on the table. Almost everything a language server does is, underneath, the bookkeeping of a cache: which derived facts are still valid, which have just gone stale, and which can be quietly skipped.</p>
+
+## What the IDE has to compute, on every keystroke
+
+Type a character. The editor expects, more or less immediately, a list of plausible completions, a hover tooltip if you pause, red squigglies under anything that no longer type-checks, and a working F12 if you ask to jump to the definition of the symbol your cursor is on. Find-references should return inside a second on a large monorepo.
+
+The informal latency budgets are well known. Completion needs to feel instant, which in practice means a round trip under about 100 ms. Diagnostics — the red and yellow underlines — can take a little longer, perhaps 300 ms, before the user notices the lag. Hover and go-to-definition sit somewhere in between. The input is not small: a working IDE session might have 30,000 source files open in the project graph and a few megabytes of code changing per minute.
+
+The engineering problem is not "understand the program." It is "understand the program in 80 milliseconds, again, after the user pressed one more key."
+
+So the server caches. A lot.
+
+## The user's view
+
+The red squiggle under a typo is the visible end of a chain of derived data: lexer tokens, a parse tree, name resolution, a type-check result, a list of diagnostics for the file. The completion popup is a query against the same name resolution plus a ranker. F12 — go-to-definition — walks from the cursor's syntactic position to the resolved symbol and back out to a source location. Find-references inverts that walk across every file that imports the symbol's containing module.
+
+Each of these features corresponds to a different slice of derived data. The server's job is to keep all of those slices current as the user edits, without recomputing the slices that nothing has touched.
+
+## LSP, the protocol
+
+LSP is the Language Server Protocol — a JSON-RPC interface between the editor (the client) and a separate language-server process (one per workspace, typically). The editor sends notifications and requests over stdio or a TCP socket; the server replies with results or pushes diagnostics back. The split matters: the parser, type checker, and indexer live in the server, not in the editor, which is why VS Code, Neovim, Emacs, and Zed can all light up Rust files identically as long as a `rust-analyzer` binary is on the path.
+
+The canonical request and notification kinds are a short list. `textDocument/didChange` tells the server a buffer's contents have changed. `textDocument/completion` asks for completion candidates at a position. `textDocument/definition` and `textDocument/references` are the navigation queries. `textDocument/hover` returns the tooltip. `textDocument/publishDiagnostics` is the server-to-client push that paints the squigglies.
+
+The 2016 insight that unlocked the modern editor ecosystem was simple. Before LSP, every (editor, language) pair was its own integration; Microsoft published the protocol alongside VS Code, and the matrix collapsed into a row plus a column<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>. One server, any editor.
+
+```jsonc
+// JSON-RPC 2.0 over LSP 3.17. Client notifies the server of an edit;
+// server later pushes diagnostics for the same document.
+{"jsonrpc": "2.0", "method": "textDocument/didChange", "params": {
+  "textDocument": {"uri": "file:///src/main.rs", "version": 42},
+  "contentChanges": [
+    {"range": {"start": {"line": 12, "character": 8},
+               "end":   {"line": 12, "character": 8}},
+     "text": "x"}
+  ]
+}}
+{"jsonrpc": "2.0", "method": "textDocument/publishDiagnostics", "params": {
+  "uri": "file:///src/main.rs",
+  "version": 42,
+  "diagnostics": [
+    {"range": {"start": {"line": 12, "character": 0},
+               "end":   {"line": 12, "character": 9}},
+     "severity": 1, "code": "E0425",
+     "message": "cannot find value `fxoo` in this scope"}
+  ]
+}}
+```
+
+## Analogy: a spreadsheet that knows what to recompute
+
+Picture a spreadsheet with a few million cells, where most cells are formulas referencing other cells. Edit one input. The engine does not re-evaluate every formula on the sheet; it walks the dependency graph it has been tracking all along, marks only the cells that transitively depend on the changed input, and recomputes those. Everything else stays exactly as it was.
+
+A language server is the same idea applied to source code. Files are input cells. Tokens, syntax trees, resolved names, and types are formula cells, each one a pure function of the cells it reads. When a byte of a file changes, only the dependents are dirtied.
+
+**Where the analogy breaks:**
+- Spreadsheet cells hold a scalar; an AST or a symbol table is a large structured value, and "did this value change?" needs a real equality check or a content hash to be useful as a propagation guard.
+- Spreadsheet dependencies are declared by the formula's static references. In a language server, the dependencies of "the type of `foo`" depend on what `foo` resolves to, which is itself a query result — dependencies are discovered dynamically as queries execute.
+- Spreadsheets recompute eagerly on edit. IDEs recompute lazily, on demand, because most derived facts are never asked for in a given second of editing.
+- A spreadsheet does not have to finish in 80 ms or lose to the user's perception of lag.
+
+## The cache-invalidation problem
+
+Phil Karlton was right about cache invalidation. A language server is the working example.
+
+The inputs are concrete: the contents of every open buffer, file-watcher events from disk, the project manifest (`Cargo.toml`, `tsconfig.json`, `pyproject.toml`), and toolchain settings. The derived facts form a layered DAG: per-file token streams; per-file parse trees; per-module name resolution; cross-module symbol tables; type-check results; per-file diagnostics. A `find-references` result for a public symbol is a transitive consumer of half the project's name resolution.
+
+The question on every keystroke is: of all those derived facts, which ones depend on the byte that just changed, and which ones can be reused as-is? The naive answer — invalidate everything — is what makes a language server feel slow. The correct answer requires the server to have remembered which inputs each query actually read, so that on an edit it can mark only the affected subgraph dirty and leave the rest green.
+
+This is what a query system does. Every query is a memoised pure function of its inputs. The system records the dependency edge at the moment the query reads another query's result. On an input change, dependents are marked stale; when something asks for them again, they re-run. If their re-run produces a value equal to the previous one, the dirty mark stops propagating — downstream queries can stay cached. That last property is the difference between fast and slow.
+
+If your IDE takes a coffee break on every keystroke, the IDE has lost.
+
+## Salsa, red-green, and the alternatives
+
+rust-analyzer is built on `salsa`, a Rust crate for exactly this style of incremental computation<sup className="fn-ref"><a href="#fn-2">[2]</a></sup>. Each query is a function annotated so that salsa memoises its result and tracks which other queries it called. On an input edit, salsa marks dependents "red" (definitely stale) or leaves them "green" (possibly stale, recheck on demand). When a red query is re-evaluated and turns out to produce a structurally equal result, its own dependents can return to green without running again. The mechanism is sometimes called the red-green algorithm; rust-analyzer's architecture notes describe how the language-server queries map onto it<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>.
+
+The alternatives have similar shapes with different trade-offs. Roslyn, the .NET compiler platform, exposes a compiler-as-a-service with immutable syntax and semantic snapshots: each edit produces a new `Compilation` value that shares structure with the previous one, and incremental work happens because new snapshots reuse the old snapshot's analyses where inputs are identical<sup className="fn-ref"><a href="#fn-4">[4]</a></sup>. Bazel and Buck go in the other direction: a coarse-grained, file-level, content-addressed action cache where the unit of reuse is a whole build action rather than a per-function query. Both extremes work; they trade granularity for bookkeeping cost.
+
+## A comparison table
+
+<table className="encoding-table">
+  <thead>
+    <tr><th>System</th><th>Granularity</th><th>Invalidation strategy</th><th>Strength</th><th>Weakness</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>rust-analyzer (salsa)</td><td>Per-query, per-input</td><td>Red-green with value-equality short-circuit</td><td>Minimal recomputation; fine-grained dependency tracking</td><td>Memory footprint grows with query count; macro-heavy code stresses the model</td></tr>
+    <tr><td>Roslyn (.NET)</td><td>Per-compilation snapshot</td><td>Persistent immutable trees; structural sharing across snapshots</td><td>Clean concurrency model; easy to host as a service</td><td>Snapshot churn on every edit; allocator pressure</td></tr>
+    <tr><td>TypeScript language service</td><td>Project graph + per-file cache</td><td>Version-stamped source files; project references rebuilt on graph change</td><td>Handles huge JS/TS monorepos with `--build` mode</td><td>Whole-project type-check still the slow path on cold start</td></tr>
+    <tr><td>pyright</td><td>In-memory typed AST per module</td><td>Module-level invalidation with import-graph propagation</td><td>Single-threaded but very fast; trivial to embed</td><td>Loses cache on restart; no persistent index</td></tr>
+    <tr><td>Bazel / Buck</td><td>Build action (whole-file inputs)</td><td>Content-addressed action cache, hermetic inputs</td><td>Reproducible, shareable across a team</td><td>Coarse: a one-byte change in a header invalidates everything that included it</td></tr>
+  </tbody>
+</table>
+
+## A query DAG, with one input flipped
+
+<figure className="chapter-figure">
+  <svg id="query-dag" viewBox="0 0 800 360" width="100%" role="img" aria-labelledby="dag-title dag-desc" style={{color: 'currentColor'}}>
+    <title id="dag-title">A small query DAG with one changed input invalidating the path to a derived diagnostic</title>
+    <desc id="dag-desc">Three leaf nodes at the bottom represent source files; the middle layer holds per-file AST nodes; above that a cross-file symbol table; the root is diagnostics for file X. The middle leaf is marked changed; dashed edges trace the invalidation path upward.</desc>
+
+    <g fontSize="12" fill="currentColor">
+      <text x="400" y="24" textAnchor="middle" fontSize="15" fontWeight="600">queries: leaves are inputs, root is a published diagnostic</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.5" fill="none">
+      <rect x="120" y="290" width="120" height="44" rx="6" />
+      <rect x="340" y="290" width="120" height="44" rx="6" stroke="var(--pillar-color, var(--color-accent, currentColor))" strokeWidth="2.5" />
+      <rect x="560" y="290" width="120" height="44" rx="6" />
+    </g>
+    <g fontSize="12" fill="currentColor" textAnchor="middle">
+      <text x="180" y="316">file: a.rs</text>
+      <text x="400" y="316">file: x.rs (changed)</text>
+      <text x="620" y="316">file: b.rs</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.5" fill="none">
+      <rect x="120" y="180" width="120" height="44" rx="6" />
+      <rect x="340" y="180" width="120" height="44" rx="6" strokeDasharray="5 4" />
+      <rect x="560" y="180" width="120" height="44" rx="6" />
+    </g>
+    <g fontSize="12" fill="currentColor" textAnchor="middle">
+      <text x="180" y="206">AST(a.rs)</text>
+      <text x="400" y="206">AST(x.rs)</text>
+      <text x="620" y="206">AST(b.rs)</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.5" fill="none">
+      <rect x="280" y="100" width="240" height="44" rx="6" strokeDasharray="5 4" />
+    </g>
+    <text x="400" y="126" fontSize="12" fill="currentColor" textAnchor="middle">cross-file symbol table</text>
+
+    <g stroke="currentColor" strokeWidth="2" fill="none">
+      <rect x="300" y="30" width="200" height="44" rx="6" stroke="var(--pillar-color, var(--color-accent, currentColor))" strokeDasharray="5 4" />
+    </g>
+    <text x="400" y="56" fontSize="12" fill="currentColor" textAnchor="middle">diagnostics(x.rs)</text>
+
+    <g stroke="currentColor" strokeWidth="1.2" fill="none">
+      <line x1="180" y1="290" x2="180" y2="224" />
+      <line x1="620" y1="290" x2="620" y2="224" />
+    </g>
+    <g stroke="currentColor" strokeWidth="1.5" fill="none" strokeDasharray="5 4">
+      <line x1="400" y1="290" x2="400" y2="224" />
+      <line x1="180" y1="180" x2="340" y2="144" />
+      <line x1="400" y1="180" x2="400" y2="144" />
+      <line x1="620" y1="180" x2="460" y2="144" />
+      <line x1="400" y1="100" x2="400" y2="74" />
+    </g>
+
+    <g fontSize="11" fill="currentColor" opacity="0.7">
+      <text x="40" y="316">inputs</text>
+      <text x="40" y="206">per-file</text>
+      <text x="40" y="126">cross-file</text>
+      <text x="40" y="56">root</text>
+    </g>
+  </svg>
+  <figcaption>An edit to <code>x.rs</code> invalidates only the queries on the path from that input to the published root. Solid edges remain green and reuse their cached values; dashed edges and nodes are dirty and will be recomputed on demand.</figcaption>
+</figure>
+
+## The monorepo problem
+
+A query DAG with a few thousand nodes is tractable. A monorepo introduces a different scaling failure: one type change in a widely-imported module can fan out to thousands of downstream queries. If the server actually re-runs all of them, latency budgets are gone.
+
+Real systems handle this by being selective about what counts as a change. The first technique is firewalling: fingerprint the public API surface of a module separately from its internal bodies, so that edits inside a function body do not invalidate consumers of the module's signatures. Rust's incremental compilation uses this idea, with a stable fingerprint per item that gates downstream work<sup className="fn-ref"><a href="#fn-5">[5]</a></sup>. The second is sharding: split the project graph into packages, crates, or TypeScript project references, so that an edit can be confined to the smallest unit that contains it. TypeScript's `--build` mode caches per-project outputs on disk for exactly this reason.
+
+The third technique is, with some embarrassment, lying. If a node's content hash is unchanged, the system reports it as identical even if its source location moved, its formatting changed, or its file was rewritten in place. The downstream consumer never has to know.
+
+## What shipped tooling actually uses
+
+The current production picture is concrete. rust-analyzer runs on salsa, in-process per workspace. The TypeScript language service uses a project-graph cache with per-file versioning and supports `--build` for incremental disk-cached output. Roslyn ships `Microsoft.CodeAnalysis` as the compiler-as-a-service used by Visual Studio, with immutable syntax and semantic models. pyright is a single-threaded TypeScript implementation with an in-memory typed AST cache that prioritises raw speed over persistence<sup className="fn-ref"><a href="#fn-6">[6]</a></sup>. gopls keeps a `go/packages`-derived build graph and re-imports affected packages on change.
+
+A pattern worth naming: several of the fastest new language servers (rust-analyzer, but also linters and formatters like ruff and biome) are written in Rust. The reason is mundane. Lex, parse, and walk are hot loops; predictable allocation and zero-cost abstractions are worth real milliseconds when the budget is 80.
+
+## Why this matters for the rest of the book
+
+Chapter 05 looks at AI coding assistants. The natural framing, once Chapter 04 is in your head, is that an assistant is a second cache sitting on top of the language server's cache. The retrieval index over a codebase has the same invalidation problem with the same DAG shape: file edits dirty embeddings, which dirty retrieved chunks, which dirty the prompt sent to a model. The model output is itself a derived fact with inputs that change.
+
+The latency budget is also similar — completion-style assistants live or die by sub-second responsiveness — and so are the techniques. Fingerprinting, sharding, content-addressed memoisation. The names change; the structure does not.
+
+## Notes
+
+<ol className="footnotes">
+  <li id="fn-1">Microsoft. "Language Server Protocol Specification, version 3.17." <a href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/">https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/</a></li>
+  <li id="fn-2">salsa-rs. "salsa: a generic framework for on-demand, incrementalized computation." Source repository. <a href="https://github.com/salsa-rs/salsa">https://github.com/salsa-rs/salsa</a></li>
+  <li id="fn-3">rust-lang. "rust-analyzer architecture." Developer documentation. <a href="https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/architecture.md">https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/architecture.md</a></li>
+  <li id="fn-4">dotnet. "Roslyn — The .NET Compiler Platform." Source repository. <a href="https://github.com/dotnet/roslyn">https://github.com/dotnet/roslyn</a></li>
+  <li id="fn-5">Horwitz, S., Reps, T., and Sagiv, M. "Demand interprocedural dataflow analysis." Proceedings of SIGSOFT '95, ACM SIGSOFT Symposium on the Foundations of Software Engineering, 1995. The academic ancestor of demand-driven analysis used by modern query systems. <a href="https://dl.acm.org/doi/10.1145/222124.222146">https://dl.acm.org/doi/10.1145/222124.222146</a></li>
+  <li id="fn-6">Microsoft. "pyright — static type checker for Python." Source repository. <a href="https://github.com/microsoft/pyright">https://github.com/microsoft/pyright</a></li>
+</ol>

--- a/site/content/code-intelligence/ch05-symbolic-and-neural.mdx
+++ b/site/content/code-intelligence/ch05-symbolic-and-neural.mdx
@@ -1,0 +1,213 @@
+export const meta = {
+  number: '05',
+  slug: 'symbolic-and-neural',
+  title: 'Symbolic and neural: hybrid code intelligence.',
+  summary: 'Embeddings over code, retrieval pipelines, and why the production system you actually want is a language server plus a vector index plus a model — wired up so each does what it is good at.',
+  reading: '13 min',
+};
+
+# Symbolic and neural: hybrid code intelligence.
+
+<p className="chapter-lede">Most of the AI coding tools you have used — Copilot, Cursor, Continue, Cody — are not a single model. They are an editor, a parser, a retrieval index, and a model, wired together so that each does the part of the job it is good at. The interesting engineering is in the wiring, not in the model.</p>
+
+## The two kinds of "knowing"
+
+There are two ways a piece of software can "know" something about your code, and they are different all the way down.
+
+The first is *symbolic*. This is the world of chapters one through four: parse trees, symbol tables, call graphs, dataflow facts. The information is exact. The compiler either resolved the identifier or it did not. The call graph either has an edge or it does not. These structures are deterministic and they are brittle — they break the instant the input is syntactically broken, and they say nothing about code they have never seen.
+
+The second is *neural*. This knowledge lives in model weights and in vectors — long lists of numbers — produced by a network trained on a great deal of code. The information is approximate. The model can answer questions about code it has never seen, tolerate typos and partial input, and produce fluent prose about what a function probably does. It is also confidently wrong about specifics on a regular basis.
+
+The LLM does not understand your code; it has very strong opinions about it.
+
+A production code intelligence system wants both. They are not rivals. They are good at different things, and the engineering job is to route each question to the substrate that can answer it honestly.
+
+## Embeddings over code, in plain English
+
+An embedding is a fixed-length vector of numbers — say, 384 floats — that lives in a space where "similar code" lands near "similar code." Train an encoder (a neural network whose only job is to turn text into one of these vectors) so that two implementations of the same idea, or a function and its tests, get coordinates that are close together. Close in what sense? Usually cosine similarity: the angle between the two vectors is small<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>.
+
+This chapter is staying away from how the encoder is trained. That is its own book. The engineering question, the one you actually have to answer when building anything, is two-part: *which encoder* and *which input granularity*.
+
+The granularity choice is the one most people underestimate. The unit you feed the encoder can be:
+
+- a whole file,
+- a single function or method,
+- a fixed-window slice of N tokens with some overlap,
+- a single AST node and its subtree,
+- a hunk from a diff.
+
+Each choice changes what the index is good at and what it silently fails on. We tabulate this below.
+
+## Analogy: the city map of code
+
+Picture the embedding space as a city map. Every chunk of code in your repository has been dropped at a coordinate. Similar restaurants — sorry, similar functions — cluster in the same neighbourhood. When you query the index with "function that parses an ISO-8601 timestamp," the query string is itself encoded, dropped at a coordinate, and you walk outward in a widening radius collecting whatever you find.
+
+**Where the analogy breaks:**
+- The map has 384 dimensions, not two. Most of the geometric intuition you have for cities is misleading; in high dimensions almost everything is roughly the same distance from everything else, and that "roughly" is what retrieval has to fight against.
+- Restaurants do not change. Code does. Every edit moves a coordinate; if the index has not been updated, the map is a snapshot of a city that no longer exists.
+- A city has a ground truth. An embedding space has only the encoder's opinion of similarity, and two different encoders draw two different cities from the same code.
+- "Spicy Thai" is a robust human concept. "Parses ISO-8601" is a robust human concept too, but the model's idea of what is near it includes anything that looks vaguely date-shaped, including code that does the wrong thing.
+
+## Retrieval-augmented generation, in one paragraph
+
+Retrieval-augmented generation, or RAG, is the standard plumbing<sup className="fn-ref"><a href="#fn-2">[2]</a></sup>. A query arrives. It is optionally rewritten — expanded with synonyms, decomposed into sub-queries, or reformulated by a small model. The rewritten query is encoded and the vector index returns the top-k nearest chunks. Those chunks are concatenated into a prompt, along with the original query and some instructions, and the prompt is handed to a language model. The model emits an answer.
+
+Retrieval is the unglamorous half of RAG, and also the half that decides whether the answer is right. Two systems with the same model and different retrievers produce very different output; two systems with the same retriever and different models, less so. Retrieval quality dominates final quality.
+
+And the index has to be kept in sync with the codebase. Every edit invalidates some embeddings. This is the same cache-invalidation problem from chapter four, with the difference that here a stale entry does not crash — it lies.
+
+## Granularity trade-offs
+
+The choice of chunk size is the most consequential decision in a code retrieval pipeline. The table below sketches the trade-off space.
+
+<table className="encoding-table">
+  <thead>
+    <tr><th>Granularity</th><th>Index size</th><th>Recall</th><th>Failure mode</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Whole file</td><td>Smallest (one vector per file)</td><td>Good for "which file talks about X"</td><td>One vector averages many ideas; the function you wanted is buried in noise</td></tr>
+    <tr><td>Function-level</td><td>Medium; one vector per function</td><td>Strong for "find me a function that does X"; respects the natural unit of code</td><td>Requires a parser to extract function spans; cross-function context is lost at retrieval time</td></tr>
+    <tr><td>Fixed-window chunk</td><td>Largest; many overlapping windows</td><td>Robust to languages without a parser; window straddles signature and body</td><td>Splits a function in half, splits a class in half; encoder sees half-statements</td></tr>
+    <tr><td>AST-node chunk</td><td>Medium; one vector per declaration node</td><td>Highest semantic alignment; the chunk is a real syntactic unit</td><td>Requires a working parser for every language in the repo; partial files break the chunker</td></tr>
+    <tr><td>Hunk diff</td><td>Small per commit; grows over time</td><td>Excellent for "where did this bug come from"; tied to history</td><td>Useless for queries about the current state of the code; needs a separate snapshot index</td></tr>
+  </tbody>
+</table>
+
+In practice, two indexes are common: function-level for "what does this codebase have" queries, and a fixed-window fallback for files the parser cannot handle.
+
+<figure className="chapter-figure">
+  <svg id="hybrid-pipeline" viewBox="0 0 880 360" width="100%" role="img" aria-labelledby="hp-title hp-desc" style={{color: 'currentColor'}}>
+    <title id="hp-title">Hybrid code intelligence pipeline</title>
+    <desc id="hp-desc">A source file flows into a parser producing an AST. The AST splits into two paths. The symbolic path produces a symbol table, call graph, and dataflow facts. The neural path passes through a chunker and encoder into a vector index. Both paths feed a query layer that hands a prompt to a model, which emits an answer.</desc>
+
+    <g fontSize="12" fill="currentColor" textAnchor="middle">
+      <rect x="20" y="160" width="100" height="40" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="70" y="184">source file</text>
+
+      <rect x="160" y="160" width="80" height="40" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="200" y="184">parser</text>
+
+      <rect x="280" y="160" width="70" height="40" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="315" y="184">AST</text>
+
+      <rect x="400" y="40" width="110" height="36" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="455" y="62">symbol table</text>
+
+      <rect x="400" y="92" width="110" height="36" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="455" y="114">call graph</text>
+
+      <rect x="400" y="144" width="110" height="36" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="455" y="166">dataflow</text>
+
+      <rect x="400" y="220" width="110" height="36" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="455" y="242">chunker</text>
+
+      <rect x="400" y="272" width="110" height="36" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="455" y="294">encoder</text>
+
+      <rect x="550" y="246" width="110" height="36" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="605" y="268">vector index</text>
+
+      <rect x="700" y="120" width="110" height="40" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="755" y="144">query layer</text>
+
+      <rect x="700" y="180" width="110" height="40" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="755" y="204">model</text>
+
+      <rect x="700" y="240" width="110" height="40" fill="none" stroke="currentColor" strokeWidth="1.5" rx="4" />
+      <text x="755" y="264">answer</text>
+
+      <text x="455" y="20" fontSize="11" opacity="0.7">symbolic</text>
+      <text x="455" y="334" fontSize="11" opacity="0.7">neural</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.5" fill="none">
+      <line x1="120" y1="180" x2="160" y2="180" />
+      <line x1="240" y1="180" x2="280" y2="180" />
+      <line x1="350" y1="180" x2="400" y2="58" />
+      <line x1="350" y1="180" x2="400" y2="110" />
+      <line x1="350" y1="180" x2="400" y2="162" />
+      <line x1="350" y1="180" x2="400" y2="238" />
+      <line x1="510" y1="238" x2="555" y2="262" stroke="currentColor" />
+      <line x1="455" y1="272" x2="455" y2="256" opacity="0" />
+      <path d="M 510 290 Q 530 290 545 280" />
+      <line x1="660" y1="264" x2="700" y2="200" />
+      <line x1="510" y1="58" x2="700" y2="140" />
+      <line x1="510" y1="110" x2="700" y2="140" />
+      <line x1="510" y1="162" x2="700" y2="140" />
+      <line x1="755" y1="160" x2="755" y2="180" />
+      <line x1="755" y1="220" x2="755" y2="240" />
+    </g>
+
+    <g stroke="var(--pillar-color, var(--color-accent, currentColor))" strokeWidth="2.5" fill="none">
+      <line x1="660" y1="264" x2="700" y2="200" />
+    </g>
+  </svg>
+  <figcaption>The same AST is the parent of both substrates. The symbolic side produces exact, queryable structures; the neural side produces approximate, queryable coordinates. The highlighted edge is the path that delivers retrieved chunks into the model's context.</figcaption>
+</figure>
+
+## A small worked retrieval call
+
+The minimum viable shape of a retrieval step is shorter than people expect. The code below uses `sentence-transformers` for encoding and a plain NumPy dot product for top-k. In a real system the dot product is delegated to a vector store such as Chroma or FAISS; the logic is the same.
+
+```python
+# Python 3.11+; assumes `chunks` is a list of {"id": str, "text": str}
+# and `chunk_vecs` is an (N, D) numpy array already encoded offline.
+from sentence_transformers import SentenceTransformer
+import numpy as np
+
+model = SentenceTransformer("all-MiniLM-L6-v2")
+
+def topk(query: str, k: int = 5) -> list[str]:
+    q = model.encode(query, normalize_embeddings=True)
+    scores = chunk_vecs @ q  # cosine, since both sides are unit-norm
+    idx = np.argpartition(-scores, k)[:k]
+    return [chunks[i]["id"] for i in idx[np.argsort(-scores[idx])]]
+```
+
+This is the entire neural side of a retrieval system at low resolution. Everything else — query rewriting, reranking, hybrid scoring with BM25, deduplication, freshness filters — is decoration on this loop.
+
+## Where the symbolic side stays in the loop
+
+Some questions are symbolic and should not be passed to a model under any circumstances.
+
+Rename-symbol is symbolic. The language server knows every binding site of an identifier; the model knows a plausible-looking subset and will quietly miss the one in the macro. Go-to-definition is symbolic. Find-all-references is symbolic. These are exact queries on the call graph, and an LLM in the loop only adds latency and a non-zero error rate.
+
+"Explain this function in English" is neural. There is no symbolic structure that produces English prose. Use the model.
+
+"Find me functions that look like this one" can be either. Symbolic clone detection compares AST subtrees and returns code that is structurally similar — same loop nest, same control flow shape. Neural similarity returns code that is semantically similar in the encoder's opinion — same idea, possibly very different syntax. The two sets are not the same. A mature system runs both and lets the user pick.
+
+A useful trick at the boundary: hallucinated identifiers can be filtered after the fact. If the model emits `user.validate_email()`, ask the symbol table whether `validate_email` is a real method on the `User` class. If it is not, drop the suggestion or flag it. Yes, the model will confidently invent a function. The parser will not.
+
+## Production landscape
+
+A non-exhaustive survey of how shipped tools wire this up. Cursor and Continue maintain a retrieval index over the open workspace and inject top-k results into the chat context. GitHub Copilot Chat performs workspace retrieval through its `@workspace` agent. Sourcegraph Cody combines symbolic graph search (its precise code intel infrastructure) with embeddings, and routes structural queries to the former and semantic queries to the latter. Aider takes a different route: it builds a `repo-map` using tree-sitter — a compact symbolic summary of the repository — and passes that to the model instead of, or alongside, retrieved chunks.
+
+The author's `tell-me-why` is a local-first RAG pipeline over source code. It uses Ollama<sup className="fn-ref"><a href="#fn-3">[3]</a></sup> for inference, Chroma<sup className="fn-ref"><a href="#fn-4">[4]</a></sup> as the vector store, `sentence-transformers`<sup className="fn-ref"><a href="#fn-5">[5]</a></sup> for encoding, and six language parsers for chunk extraction. Everything stays on the operator's machine. No code leaves the laptop.
+
+## Operational complexity
+
+Things that go wrong in production, in roughly the order they will bite you. The index goes stale — a file changed, the embedding did not, retrieval returns code that no longer exists; tie the index to a content hash and re-embed on change. The context window overflows — top-k pulled in too much and the prompt is truncated mid-chunk; rerank and trim, or summarize before injection.
+
+Embeddings drift between encoder versions. Old vectors and new vectors live in different geometric spaces, and cosine similarity between them is noise. Re-embed the entire corpus on encoder change. There is no shortcut.
+
+The query is the wrong granularity — the user asked about a class, the index is chunked by function, no single chunk matches; query at multiple granularities and fuse. Cold-cache retrieval latency hurts the first query after a restart; keep the index resident, or accept the cost as part of the UX.
+
+## Where the book ends
+
+The spine of this book has been the same idea in five variations: structure first, syntax second. A lexer is a cache over characters. A parser is a cache over tokens. A language server is a cache over parses. A retrieval index is a cache over the language server's worldview, projected into a vector space. A model is the layer on top of all of these with the worst guarantees and the most impressive party tricks.
+
+Symbolic and neural are not rivals. They are tiers of the same stack, each making different latency-correctness trade-offs. The interesting systems route each query to the tier that can answer it without lying.
+
+Three concrete next builds, in increasing order of effort. Write a tiny static analyzer that walks an AST and emits one structured finding — chapter three made real. Write a tiny LSP-speaking server that responds to `textDocument/hover` with a symbol table lookup — chapter four made real. Write a tiny RAG-over-repo pipeline that chunks at the function level, embeds with a small model, and answers a single fixed question — this chapter made real. Each fits in an afternoon and teaches more than any survey. The book closes here.
+
+## Notes
+
+<ol className="footnotes">
+  <li id="fn-1">Guo, D. et al. "UniXcoder: Unified Cross-Modal Pre-training for Code Representation." ACL 2022. <a href="https://arxiv.org/abs/2203.03850">https://arxiv.org/abs/2203.03850</a></li>
+  <li id="fn-2">Lewis, P. et al. "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks." NeurIPS 2020. <a href="https://arxiv.org/abs/2005.11401">https://arxiv.org/abs/2005.11401</a></li>
+  <li id="fn-3">Karpukhin, V. et al. "Dense Passage Retrieval for Open-Domain Question Answering." EMNLP 2020. <a href="https://arxiv.org/abs/2004.04906">https://arxiv.org/abs/2004.04906</a></li>
+  <li id="fn-4">Ollama: local-first model serving. <a href="https://github.com/ollama/ollama">https://github.com/ollama/ollama</a></li>
+  <li id="fn-5">Chroma: open-source embedding database. <a href="https://github.com/chroma-core/chroma">https://github.com/chroma-core/chroma</a></li>
+  <li id="fn-6">Reimers, N. and Gurevych, I. "Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks." EMNLP 2019. <a href="https://www.sbert.net/">https://www.sbert.net/</a></li>
+</ol>

--- a/site/styles/globals.css
+++ b/site/styles/globals.css
@@ -1097,6 +1097,11 @@ main[data-pillar="photonics"] {
   --pillar-color: var(--color-pillar-photonics);
 }
 
+/* ── Code intelligence book ── */
+main[data-pillar="code-int"] {
+  --pillar-color: var(--color-pillar-code);
+}
+
 .book-eyebrow,
 .chapter-eyebrow {
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary

This PR adds a complete five-chapter book on code intelligence to the writing section, covering parsers, static analysis, language servers, and hybrid symbolic-neural systems. The book is structured similarly to the existing "Photonics" book with a table of contents page and individual chapter pages.

## Key Changes

- **New book content**: Five MDX chapters covering:
  - Chapter 01: Structure vs. surface (why code intelligence matters)
  - Chapter 02: Lexing and parsing (CST/AST, incremental parsing)
  - Chapter 03: Control flow and dataflow (static analysis fundamentals)
  - Chapter 04: Language servers (LSP, incremental caching, cache invalidation)
  - Chapter 05: Symbolic and neural (hybrid pipelines, embeddings, RAG)

- **New routing and pages**:
  - `site/app/writing/code-intelligence/page.tsx` - Book landing page with chapter TOC
  - `site/app/writing/code-intelligence/[slug]/page.tsx` - Individual chapter pages with navigation
  - `site/app/writing/code-intelligence/chapters.ts` - Chapter metadata and configuration

- **Integration**:
  - Updated `site/app/writing/page.tsx` to include the new book in the writing index
  - Added CSS variable `--color-pillar-code` styling in `site/styles/globals.css`

## Implementation Details

- Each chapter includes metadata (number, slug, title, summary, reading time) exported from the MDX files
- Chapter pages support previous/next navigation between chapters
- Static params generation for all chapter routes
- Metadata generation for SEO (title and description per chapter)
- Consistent styling with the existing Photonics book structure

https://claude.ai/code/session_01F4DHg9xqoPHzJD6MhjmXm6