### PR TITLE
Add chapter sidebar navigation and inline SVG figures

### DIFF
--- a/site/app/writing/code-intelligence/[slug]/page.tsx
+++ b/site/app/writing/code-intelligence/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import ChapterSidebar from '@/components/ChapterSidebar';
 import FooterSignature from '@/components/FooterSignature';
 import { CHAPTERS } from '../chapters';
 
@@ -63,9 +64,18 @@ export default async function CodeIntelligenceChapterPage({
         <span aria-hidden="true"> · </span>
         <span>{chapter.reading}</span>
       </p>
-      <article className="chapter-article">
-        <Body />
-      </article>
+      <div className="chapter-layout">
+        <ChapterSidebar
+          bookLabel="Code intelligence"
+          bookHref="/writing/code-intelligence/"
+          basePath="/writing/code-intelligence/"
+          chapters={CHAPTERS}
+          currentSlug={slug}
+        />
+        <article className="chapter-article">
+          <Body />
+        </article>
+      </div>
       <nav className="chapter-nav" aria-label="Chapter navigation">
         {prev !== undefined ? (
           <Link

--- a/site/app/writing/photonics/[slug]/page.tsx
+++ b/site/app/writing/photonics/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import ChapterSidebar from '@/components/ChapterSidebar';
 import FooterSignature from '@/components/FooterSignature';
 import { CHAPTERS } from '../chapters';
 
@@ -63,9 +64,18 @@ export default async function PhotonicsChapterPage({
         <span aria-hidden="true"> · </span>
         <span>{chapter.reading}</span>
       </p>
-      <article className="chapter-article">
-        <Body />
-      </article>
+      <div className="chapter-layout">
+        <ChapterSidebar
+          bookLabel="Photonic QC"
+          bookHref="/writing/photonics/"
+          basePath="/writing/photonics/"
+          chapters={CHAPTERS}
+          currentSlug={slug}
+        />
+        <article className="chapter-article">
+          <Body />
+        </article>
+      </div>
       <nav className="chapter-nav" aria-label="Chapter navigation">
         {prev !== undefined ? (
           <Link href={`/writing/photonics/${prev.slug}/`} className="chapter-nav__prev">

--- a/site/components/ChapterSidebar.tsx
+++ b/site/components/ChapterSidebar.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link';
+
+export type SidebarChapter = {
+  number: string;
+  slug: string;
+  title: string;
+};
+
+export default function ChapterSidebar({
+  bookLabel,
+  bookHref,
+  basePath,
+  chapters,
+  currentSlug,
+}: {
+  bookLabel: string;
+  bookHref: string;
+  basePath: string;
+  chapters: ReadonlyArray<SidebarChapter>;
+  currentSlug: string;
+}) {
+  return (
+    <aside className="chapter-sidebar" aria-label="Book contents">
+      <Link href={bookHref} className="chapter-sidebar__book">
+        {bookLabel}
+      </Link>
+      <ol className="chapter-sidebar__list">
+        {chapters.map((c) => {
+          const isCurrent = c.slug === currentSlug;
+          return (
+            <li
+              key={c.slug}
+              className={
+                isCurrent
+                  ? 'chapter-sidebar__item is-current'
+                  : 'chapter-sidebar__item'
+              }
+            >
+              <Link
+                href={`${basePath}${c.slug}/`}
+                className="chapter-sidebar__link"
+                aria-current={isCurrent ? 'page' : undefined}
+              >
+                <span className="chapter-sidebar__num">{c.number}</span>
+                <span className="chapter-sidebar__title">{c.title}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+    </aside>
+  );
+}

--- a/site/content/code-intelligence/ch01-structure-not-surface.mdx
+++ b/site/content/code-intelligence/ch01-structure-not-surface.mdx
@@ -137,6 +137,80 @@ The first row is the cheap demo. The last three rows are why a thirty-year-old i
 
 The pipeline is not a strict left-to-right waterfall in production tools — incremental parsers reuse old tree fragments, and language servers cache symbol tables between keystrokes — but the layers exist and the dependencies point in this direction. Chapters 02 through 04 walk each transition in detail.
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 360" width="100%" role="img" aria-labelledby="ast-title ast-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="ast-title">An AST for total = price + quantity * discount</title>
+    <desc id="ast-desc">A tree diagram of the assignment expression total = price + quantity * discount. The root is an Assignment node with two children: the identifier total and a BinaryOp plus, which itself has price on the left and a BinaryOp times on the right, whose children are quantity and discount.</desc>
+
+    <g stroke="currentColor" strokeWidth="1.5" fill="none" opacity="0.55">
+      <line x1="410" y1="70" x2="240" y2="140" />
+      <line x1="410" y1="70" x2="580" y2="140" />
+      <line x1="580" y1="170" x2="440" y2="240" />
+      <line x1="580" y1="170" x2="720" y2="240" />
+      <line x1="720" y1="270" x2="600" y2="330" />
+      <line x1="720" y1="270" x2="800" y2="330" />
+    </g>
+
+    <g>
+      <g transform="translate(410 70)">
+        <rect x="-90" y="-22" width="180" height="44" rx="6" fill="var(--pillar-color, currentColor)" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="-2" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Assignment</text>
+        <text x="0" y="15" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">target = value</text>
+      </g>
+
+      <g transform="translate(240 160)">
+        <rect x="-70" y="-22" width="140" height="44" rx="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="-2" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">Identifier</text>
+        <text x="0" y="14" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace" fill="var(--pillar-color, currentColor)">total</text>
+      </g>
+
+      <g transform="translate(580 160)">
+        <rect x="-70" y="-22" width="140" height="44" rx="6" fill="var(--pillar-color, currentColor)" fillOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="-2" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">BinaryOp</text>
+        <text x="0" y="14" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace" fill="var(--pillar-color, currentColor)">+</text>
+      </g>
+
+      <g transform="translate(440 260)">
+        <rect x="-70" y="-22" width="140" height="44" rx="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="-2" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">Identifier</text>
+        <text x="0" y="14" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace" fill="var(--pillar-color, currentColor)">price</text>
+      </g>
+
+      <g transform="translate(720 260)">
+        <rect x="-70" y="-22" width="140" height="44" rx="6" fill="var(--pillar-color, currentColor)" fillOpacity="0.08" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="-2" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">BinaryOp</text>
+        <text x="0" y="14" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace" fill="var(--pillar-color, currentColor)">*</text>
+      </g>
+
+      <g transform="translate(600 340)">
+        <rect x="-60" y="-18" width="120" height="34" rx="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="4" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace" fill="var(--pillar-color, currentColor)">quantity</text>
+      </g>
+
+      <g transform="translate(800 340)">
+        <rect x="-60" y="-18" width="120" height="34" rx="6" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="4" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace" fill="var(--pillar-color, currentColor)">discount</text>
+      </g>
+    </g>
+
+    <g transform="translate(40 70)">
+      <text x="0" y="0" fontSize="11" fontFamily="ui-monospace, monospace" fill="currentColor" opacity="0.7">source</text>
+      <text x="0" y="22" fontSize="13" fontFamily="ui-monospace, monospace" fill="currentColor">total =</text>
+      <text x="0" y="42" fontSize="13" fontFamily="ui-monospace, monospace" fill="currentColor">  price +</text>
+      <text x="0" y="62" fontSize="13" fontFamily="ui-monospace, monospace" fill="currentColor">  quantity</text>
+      <text x="0" y="82" fontSize="13" fontFamily="ui-monospace, monospace" fill="currentColor">  * discount</text>
+      <line x1="180" y1="50" x2="220" y2="50" stroke="currentColor" strokeWidth="1.4" markerEnd="url(#ast-arrow)" />
+    </g>
+
+    <defs>
+      <marker id="ast-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+        <path d="M0,0 L7,3.5 L0,7 z" fill="currentColor" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>The same five-token expression as a tree. Operator precedence (* binds tighter than +) is now structural rather than implicit; you can ask "what is the right-hand side of the assignment?" with a single field access. The text says nothing about precedence — the tree settles it once.</figcaption>
+</figure>
+
 ## What shipped tooling actually uses
 
 The pipeline is not abstract. You can name the projects that implement each stage.

--- a/site/content/code-intelligence/ch02-lexing-and-parsing.mdx
+++ b/site/content/code-intelligence/ch02-lexing-and-parsing.mdx
@@ -156,6 +156,129 @@ The pattern across the table is the same: the more friendly the algorithm is to 
   <figcaption>The pipeline reads left to right on every keystroke in an IDE. The lexer collapses byte offsets into typed tokens. The parser assembles a CST that preserves trivia and tolerates broken input. A later pass produces the AST by dropping trivia and merging syntactic sugar; that is the tree most compiler back-ends consume.</figcaption>
 </figure>
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 880 400" width="100%" role="img" aria-labelledby="cstast-title cstast-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="cstast-title">CST and AST side-by-side for the same expression</title>
+    <desc id="cstast-desc">Two trees rendered next to each other. On the left, the CST for the snippet if x is greater than zero then return x, with every token preserved, including the if keyword, parens, braces, and semicolon. On the right, the same construct as a slimmer AST with only the condition, the then-block, and a return statement carrying the expression x.</desc>
+
+    <text x="220" y="32" textAnchor="middle" fontSize="14" fontWeight="600" fill="currentColor">CST — every byte accounted for</text>
+    <text x="660" y="32" textAnchor="middle" fontSize="14" fontWeight="600" fill="currentColor">AST — only what semantics needs</text>
+
+    <line x1="440" y1="50" x2="440" y2="380" stroke="currentColor" strokeWidth="0.6" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(0 60)" fill="currentColor">
+      <g stroke="currentColor" strokeWidth="1.4" fill="none" opacity="0.55">
+        <line x1="220" y1="20" x2="60" y2="80" />
+        <line x1="220" y1="20" x2="160" y2="80" />
+        <line x1="220" y1="20" x2="220" y2="80" />
+        <line x1="220" y1="20" x2="280" y2="80" />
+        <line x1="220" y1="20" x2="380" y2="80" />
+        <line x1="220" y1="80" x2="180" y2="140" />
+        <line x1="220" y1="80" x2="220" y2="140" />
+        <line x1="220" y1="80" x2="260" y2="140" />
+        <line x1="380" y1="80" x2="320" y2="160" />
+        <line x1="380" y1="80" x2="380" y2="160" />
+        <line x1="380" y1="80" x2="440" y2="160" />
+        <line x1="380" y1="160" x2="380" y2="220" />
+        <line x1="380" y1="220" x2="320" y2="280" />
+        <line x1="380" y1="220" x2="380" y2="280" />
+        <line x1="380" y1="220" x2="440" y2="280" />
+      </g>
+
+      <g>
+        <g transform="translate(220 20)">
+          <rect x="-45" y="-14" width="90" height="28" rx="5" fill="var(--pillar-color, currentColor)" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.4" />
+          <text x="0" y="4" textAnchor="middle" fontSize="11" fontWeight="600">IfStmt</text>
+        </g>
+        <g transform="translate(60 80)" fontSize="10" fontFamily="ui-monospace, monospace">
+          <rect x="-30" y="-12" width="60" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="3" textAnchor="middle">"if"</text>
+        </g>
+        <g transform="translate(160 80)" fontSize="10" fontFamily="ui-monospace, monospace">
+          <rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="3" textAnchor="middle">" "</text>
+        </g>
+        <g transform="translate(220 80)">
+          <rect x="-40" y="-12" width="80" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="3" textAnchor="middle" fontSize="10">BinExpr</text>
+        </g>
+        <g transform="translate(280 80)" fontSize="10" fontFamily="ui-monospace, monospace">
+          <rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="3" textAnchor="middle">" "</text>
+        </g>
+        <g transform="translate(380 80)">
+          <rect x="-35" y="-12" width="70" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="3" textAnchor="middle" fontSize="10">Block</text>
+        </g>
+
+        <g fontSize="10" fontFamily="ui-monospace, monospace">
+          <g transform="translate(180 140)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">x</text></g>
+          <g transform="translate(220 140)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">{'>'}</text></g>
+          <g transform="translate(260 140)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">0</text></g>
+        </g>
+
+        <g fontSize="10" fontFamily="ui-monospace, monospace">
+          <g transform="translate(320 160)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">{'{'}</text></g>
+          <g transform="translate(380 160)">
+            <rect x="-40" y="-12" width="80" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" />
+            <text x="0" y="3" textAnchor="middle">RetStmt</text>
+          </g>
+          <g transform="translate(440 160)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">{'}'}</text></g>
+        </g>
+
+        <g fontSize="10" fontFamily="ui-monospace, monospace">
+          <g transform="translate(380 220)">
+            <rect x="-32" y="-12" width="64" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" />
+            <text x="0" y="3" textAnchor="middle">tokens</text>
+          </g>
+          <g transform="translate(320 280)"><rect x="-22" y="-12" width="44" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">"return"</text></g>
+          <g transform="translate(380 280)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">x</text></g>
+          <g transform="translate(440 280)"><rect x="-15" y="-12" width="30" height="24" rx="4" fill="none" stroke="currentColor" strokeWidth="1.1" /><text x="0" y="3" textAnchor="middle">;</text></g>
+        </g>
+      </g>
+    </g>
+
+    <g transform="translate(480 60)" fill="currentColor">
+      <g stroke="currentColor" strokeWidth="1.4" fill="none" opacity="0.55">
+        <line x1="180" y1="20" x2="80" y2="100" />
+        <line x1="180" y1="20" x2="280" y2="100" />
+        <line x1="80" y1="100" x2="40" y2="180" />
+        <line x1="80" y1="100" x2="120" y2="180" />
+        <line x1="280" y1="100" x2="280" y2="180" />
+      </g>
+
+      <g>
+        <g transform="translate(180 20)">
+          <rect x="-50" y="-14" width="100" height="28" rx="5" fill="var(--pillar-color, currentColor)" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.4" />
+          <text x="0" y="4" textAnchor="middle" fontSize="11" fontWeight="600">If</text>
+        </g>
+        <g transform="translate(80 100)">
+          <rect x="-50" y="-14" width="100" height="28" rx="5" fill="none" stroke="currentColor" strokeWidth="1.3" />
+          <text x="0" y="4" textAnchor="middle" fontSize="11">cond: BinOp</text>
+        </g>
+        <g transform="translate(280 100)">
+          <rect x="-50" y="-14" width="100" height="28" rx="5" fill="none" stroke="currentColor" strokeWidth="1.3" />
+          <text x="0" y="4" textAnchor="middle" fontSize="11">then: Return</text>
+        </g>
+        <g transform="translate(40 200)" fontFamily="ui-monospace, monospace" fontSize="11">
+          <rect x="-22" y="-14" width="44" height="28" rx="5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="4" textAnchor="middle" fill="var(--pillar-color, currentColor)">x</text>
+        </g>
+        <g transform="translate(120 200)" fontFamily="ui-monospace, monospace" fontSize="11">
+          <rect x="-22" y="-14" width="44" height="28" rx="5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="4" textAnchor="middle" fill="var(--pillar-color, currentColor)">0</text>
+        </g>
+        <g transform="translate(280 200)" fontFamily="ui-monospace, monospace" fontSize="11">
+          <rect x="-26" y="-14" width="52" height="28" rx="5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+          <text x="0" y="4" textAnchor="middle" fill="var(--pillar-color, currentColor)">x</text>
+        </g>
+        <text x="80" y="125" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.65">op: &gt;</text>
+      </g>
+    </g>
+  </svg>
+  <figcaption>The same one-line conditional, two ways. The CST keeps every keyword, brace, and whitespace token: the file can be reconstructed byte-for-byte by walking it left to right. The AST drops the punctuation and the trivia, collapsing the braced block into three children — condition, then-branch, and the expression being returned. The AST is what semantic passes consume; the CST is what the IDE keeps around for refactors and formatters.</figcaption>
+</figure>
+
 ## Incremental parsing and error recovery
 
 If you re-parsed the whole file on every keystroke, a 100k-line file would not feel like an IDE. Incremental parsers avoid that by keeping the previous tree, finding the smallest subtree that contains the user's edit, re-parsing only that region, and splicing the new subtree back in. Tree-sitter does this in time proportional to the size of the edit, not the size of the file<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>. Roslyn, the C# compiler-as-service, does the same with a different data structure (immutable red-green trees) and the same effect: edits are cheap because the unchanged parts of the tree are shared with the previous version<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>.

--- a/site/content/code-intelligence/ch03-control-flow-and-dataflow.mdx
+++ b/site/content/code-intelligence/ch03-control-flow-and-dataflow.mdx
@@ -135,6 +135,70 @@ Five dataflow analyses cover most of what shipped linters compute. Each picks a 
   <figcaption>A toy CFG. Two assignments to <code>x</code> reach the join block along different paths; the join takes the union, so the entry to the next block holds both definitions. The highlighted edge is one of the two join edges where dataflow facts merge.</figcaption>
 </figure>
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 360" width="100%" role="img" aria-labelledby="lat-title lat-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="lat-title">Constant-propagation lattice</title>
+    <desc id="lat-desc">A Hasse diagram. Top element is ⊤ meaning unknown or not-a-constant. Below it is an unbounded row of concrete integer values labeled with five examples 0, 1, 2, 3, 4, dot dot dot. Below them is ⊥ meaning unreachable. Lines connect ⊥ to each concrete value, and each concrete value to ⊤. The join of any two distinct concrete values is ⊤; the join of any concrete value with itself is itself; the join with ⊥ is the other operand.</desc>
+
+    <g transform="translate(410 50)" fill="currentColor">
+      <circle cx="0" cy="0" r="22" fill="var(--pillar-color, currentColor)" fillOpacity="0.2" stroke="currentColor" strokeWidth="1.6" />
+      <text x="0" y="5" textAnchor="middle" fontSize="18" fontWeight="600">⊤</text>
+      <text x="40" y="5" fontSize="11" fill="currentColor" opacity="0.65">unknown / not a constant</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.2" opacity="0.55">
+      <line x1="410" y1="72" x2="120" y2="170" />
+      <line x1="410" y1="72" x2="260" y2="170" />
+      <line x1="410" y1="72" x2="410" y2="170" />
+      <line x1="410" y1="72" x2="560" y2="170" />
+      <line x1="410" y1="72" x2="700" y2="170" />
+
+      <line x1="120" y1="200" x2="410" y2="300" />
+      <line x1="260" y1="200" x2="410" y2="300" />
+      <line x1="410" y1="200" x2="410" y2="300" />
+      <line x1="560" y1="200" x2="410" y2="300" />
+      <line x1="700" y1="200" x2="410" y2="300" />
+    </g>
+
+    <g fill="currentColor">
+      <g transform="translate(120 185)">
+        <rect x="-26" y="-18" width="52" height="36" rx="6" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="1.4" />
+        <text x="0" y="5" textAnchor="middle" fontSize="14" fontFamily="ui-monospace, monospace">0</text>
+      </g>
+      <g transform="translate(260 185)">
+        <rect x="-26" y="-18" width="52" height="36" rx="6" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="1.4" />
+        <text x="0" y="5" textAnchor="middle" fontSize="14" fontFamily="ui-monospace, monospace">1</text>
+      </g>
+      <g transform="translate(410 185)">
+        <rect x="-26" y="-18" width="52" height="36" rx="6" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="1.4" />
+        <text x="0" y="5" textAnchor="middle" fontSize="14" fontFamily="ui-monospace, monospace">2</text>
+      </g>
+      <g transform="translate(560 185)">
+        <rect x="-26" y="-18" width="52" height="36" rx="6" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="1.4" />
+        <text x="0" y="5" textAnchor="middle" fontSize="14" fontFamily="ui-monospace, monospace">3</text>
+      </g>
+      <g transform="translate(700 185)">
+        <rect x="-26" y="-18" width="52" height="36" rx="6" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="1.4" />
+        <text x="0" y="5" textAnchor="middle" fontSize="14" fontFamily="ui-monospace, monospace">⋯</text>
+      </g>
+    </g>
+
+    <g transform="translate(410 310)" fill="currentColor">
+      <circle cx="0" cy="0" r="22" fill="var(--pillar-color, currentColor)" fillOpacity="0.2" stroke="currentColor" strokeWidth="1.6" />
+      <text x="0" y="5" textAnchor="middle" fontSize="18" fontWeight="600">⊥</text>
+      <text x="40" y="5" fontSize="11" fill="currentColor" opacity="0.65">unreachable / no information</text>
+    </g>
+
+    <g transform="translate(20 145)" fill="currentColor" opacity="0.7" fontSize="11">
+      <text x="0" y="0">join rule</text>
+      <text x="0" y="18">⊥ ⊔ a = a</text>
+      <text x="0" y="36">a ⊔ a = a</text>
+      <text x="0" y="54">a ⊔ b = ⊤  (a ≠ b)</text>
+    </g>
+  </svg>
+  <figcaption>The constant-propagation lattice. Concrete integer values sit in an antichain in the middle. ⊥ means "I have not learned anything yet"; ⊤ means "this variable is provably not constant." The join operator at a branch confluence collapses any two distinct concrete values to ⊤, which is why this analysis loses precision the moment two different definitions reach the same point.</figcaption>
+</figure>
+
 ## Path-sensitivity, context-sensitivity, and the cost
 
 The dataflow framework above is *flow-sensitive* — it respects the order of statements — but *path-insensitive*, meaning it joins facts from all paths into a branch into a single fact-set. A **path-sensitive** analysis tracks facts separately along each path, so it can keep "if `flag` is true then `x = 2`" as a single correlated fact instead of conservatively merging. A **context-sensitive** analysis, often called k-CFA after Shivers's dissertation<sup className="fn-ref"><a href="#fn-6">[6]</a></sup>, distinguishes facts at each call site rather than merging them at the function entry.

--- a/site/content/code-intelligence/ch04-language-servers.mdx
+++ b/site/content/code-intelligence/ch04-language-servers.mdx
@@ -167,6 +167,52 @@ The alternatives have similar shapes with different trade-offs. Roslyn, the .NET
   <figcaption>An edit to <code>x.rs</code> invalidates only the queries on the path from that input to the published root. Solid edges remain green and reuse their cached values; dashed edges and nodes are dirty and will be recomputed on demand.</figcaption>
 </figure>
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 320" width="100%" role="img" aria-labelledby="lsp-title lsp-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="lsp-title">LSP request and response over JSON-RPC</title>
+    <desc id="lsp-desc">A swim-lane sketch with editor on the left and language server on the right, connected by JSON-RPC messages. The editor sends didChange when the user types, then requests textDocument/definition for the symbol under the cursor. The server replies with the file and range. A horizontal time axis runs along the bottom.</desc>
+
+    <g fill="currentColor">
+      <text x="160" y="40" textAnchor="middle" fontSize="14" fontWeight="600">Editor (client)</text>
+      <text x="660" y="40" textAnchor="middle" fontSize="14" fontWeight="600">Language server</text>
+
+      <line x1="160" y1="60" x2="160" y2="290" stroke="currentColor" strokeWidth="1.2" opacity="0.5" />
+      <line x1="660" y1="60" x2="660" y2="290" stroke="currentColor" strokeWidth="1.2" opacity="0.5" />
+
+      <g transform="translate(0 90)">
+        <line x1="180" y1="0" x2="640" y2="0" stroke="var(--pillar-color, currentColor)" strokeWidth="1.5" markerEnd="url(#lsp-arrow)" />
+        <rect x="220" y="-22" width="380" height="22" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="0.8" rx="4" />
+        <text x="410" y="-6" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace">textDocument/didChange  {'{'} uri, contentChanges {'}'}</text>
+      </g>
+
+      <g transform="translate(0 150)">
+        <line x1="180" y1="0" x2="640" y2="0" stroke="var(--pillar-color, currentColor)" strokeWidth="1.5" markerEnd="url(#lsp-arrow)" />
+        <rect x="220" y="-22" width="380" height="22" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="0.8" rx="4" />
+        <text x="410" y="-6" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace">textDocument/definition  {'{'} uri, position {'}'}</text>
+      </g>
+
+      <g transform="translate(0 220)">
+        <line x1="640" y1="0" x2="180" y2="0" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#lsp-arrow)" />
+        <rect x="220" y="-22" width="380" height="22" fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="0.8" rx="4" />
+        <text x="410" y="-6" textAnchor="middle" fontSize="11" fontFamily="ui-monospace, monospace">Location[]  {'{'} uri: lib.rs, range: 42:5..42:10 {'}'}</text>
+      </g>
+
+      <text x="660" y="190" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.65">recompute</text>
+      <text x="660" y="204" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.65">dirty queries</text>
+
+      <line x1="160" y1="290" x2="660" y2="290" stroke="currentColor" strokeWidth="1" opacity="0.4" markerEnd="url(#lsp-arrow)" />
+      <text x="410" y="306" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.75">time →</text>
+    </g>
+
+    <defs>
+      <marker id="lsp-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+        <path d="M0,0 L8,4 L0,8 z" fill="currentColor" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>One round trip over LSP. The editor pushes diffs to the server with `didChange` and asks structured questions with `definition`, `hover`, `references`, and friends. The server's job is to answer those questions in single-digit milliseconds — which is why every piece of work that <em>can</em> be cached, is.</figcaption>
+</figure>
+
 ## The monorepo problem
 
 A query DAG with a few thousand nodes is tractable. A monorepo introduces a different scaling failure: one type change in a widely-imported module can fan out to thousands of downstream queries. If the server actually re-runs all of them, latency budgets are gone.

--- a/site/content/code-intelligence/ch05-symbolic-and-neural.mdx
+++ b/site/content/code-intelligence/ch05-symbolic-and-neural.mdx
@@ -179,6 +179,81 @@ Rename-symbol is symbolic. The language server knows every binding site of an id
 
 A useful trick at the boundary: hallucinated identifiers can be filtered after the fact. If the model emits `user.validate_email()`, ask the symbol table whether `validate_email` is a real method on the `User` class. If it is not, drop the suggestion or flag it. Yes, the model will confidently invent a function. The parser will not.
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 360" width="100%" role="img" aria-labelledby="emb-title emb-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="emb-title">Embedding space with three clusters and a query</title>
+    <desc id="emb-desc">A 2D scatter plot of small dots clustered into three groups labelled auth, parsing, and networking. A single black diamond marks a query vector. Three dashed lines connect the query to its three nearest neighbours, one in each cluster, with the closest neighbour in the auth cluster highlighted.</desc>
+
+    <g stroke="currentColor" strokeWidth="0.8" opacity="0.25" fill="none">
+      <line x1="60" y1="320" x2="780" y2="320" />
+      <line x1="60" y1="40" x2="60" y2="320" />
+    </g>
+    <text x="780" y="338" fontSize="11" fill="currentColor" opacity="0.6" textAnchor="end">dim 1</text>
+    <text x="60" y="36" fontSize="11" fill="currentColor" opacity="0.6">dim 2</text>
+
+    <g fill="var(--pillar-color, currentColor)" fillOpacity="0.6">
+      <circle cx="180" cy="130" r="5" />
+      <circle cx="200" cy="150" r="5" />
+      <circle cx="220" cy="115" r="5" />
+      <circle cx="160" cy="160" r="5" />
+      <circle cx="240" cy="135" r="5" />
+      <circle cx="210" cy="180" r="5" />
+      <circle cx="180" cy="195" r="5" />
+    </g>
+    <g fill="none" stroke="currentColor" strokeWidth="1" opacity="0.45">
+      <ellipse cx="200" cy="155" rx="70" ry="55" />
+    </g>
+    <text x="200" y="95" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">auth</text>
+
+    <g fill="currentColor" fillOpacity="0.55">
+      <circle cx="500" cy="100" r="5" />
+      <circle cx="520" cy="120" r="5" />
+      <circle cx="540" cy="90" r="5" />
+      <circle cx="480" cy="130" r="5" />
+      <circle cx="560" cy="115" r="5" />
+      <circle cx="510" cy="140" r="5" />
+    </g>
+    <g fill="none" stroke="currentColor" strokeWidth="1" opacity="0.45">
+      <ellipse cx="515" cy="115" rx="55" ry="40" />
+    </g>
+    <text x="515" y="62" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">parsing</text>
+
+    <g fill="currentColor" fillOpacity="0.55">
+      <circle cx="620" cy="240" r="5" />
+      <circle cx="650" cy="260" r="5" />
+      <circle cx="600" cy="270" r="5" />
+      <circle cx="670" cy="230" r="5" />
+      <circle cx="640" cy="290" r="5" />
+      <circle cx="680" cy="270" r="5" />
+    </g>
+    <g fill="none" stroke="currentColor" strokeWidth="1" opacity="0.45">
+      <ellipse cx="640" cy="260" rx="60" ry="40" />
+    </g>
+    <text x="640" y="320" textAnchor="middle" fontSize="12" fontWeight="600" fill="currentColor">networking</text>
+
+    <g transform="translate(320 220)">
+      <rect x="-9" y="-9" width="18" height="18" transform="rotate(45)" fill="currentColor" stroke="currentColor" strokeWidth="1.5" />
+      <text x="14" y="6" fontSize="11" fill="currentColor">query: "verify JWT"</text>
+    </g>
+
+    <g stroke="currentColor" strokeWidth="1.1" strokeDasharray="4 4" fill="none" opacity="0.7">
+      <line x1="320" y1="220" x2="240" y2="135" />
+      <line x1="320" y1="220" x2="510" y2="140" />
+      <line x1="320" y1="220" x2="600" y2="270" />
+    </g>
+    <g stroke="var(--pillar-color, currentColor)" strokeWidth="2" fill="none">
+      <line x1="320" y1="220" x2="240" y2="135" />
+    </g>
+
+    <g fill="currentColor" fontSize="11" opacity="0.75">
+      <text x="270" y="190" fontFamily="ui-monospace, monospace">0.18</text>
+      <text x="430" y="180" fontFamily="ui-monospace, monospace">0.46</text>
+      <text x="450" y="265" fontFamily="ui-monospace, monospace">0.71</text>
+    </g>
+  </svg>
+  <figcaption>A toy embedding space. Function-level code chunks cluster by topic in the encoder's geometry. A natural-language query is encoded into the same space; cosine distances pick the nearest neighbours across clusters. Retrieval is just: convert the question into a vector, return the closest chunks, hand them to the model. The closest result (auth) wins by a wide enough margin that the model gets the right context without scanning the whole repository.</figcaption>
+</figure>
+
 ## Production landscape
 
 A non-exhaustive survey of how shipped tools wire this up. Cursor and Continue maintain a retrieval index over the open workspace and inject top-k results into the chat context. GitHub Copilot Chat performs workspace retrieval through its `@workspace` agent. Sourcegraph Cody combines symbolic graph search (its precise code intel infrastructure) with embeddings, and routes structural queries to the former and semantic queries to the latter. Aider takes a different route: it builds a `repo-map` using tree-sitter — a compact symbolic summary of the repository — and passes that to the model instead of, or alongside, retrieved chunks.

--- a/site/content/photonics/ch01-qumodes-not-qubits.mdx
+++ b/site/content/photonics/ch01-qumodes-not-qubits.mdx
@@ -46,6 +46,68 @@ The same photon can carry information in surprisingly different ways, and every 
 
 The first three are qubit encodings: each logical qubit lives in a tiny two-dimensional slice of a much larger Hilbert space, and the rest of the space is either wasted or feared as "leakage." The fourth treats the entire infinite-dimensional space of the mode as the resource — no slicing, no leftover. That's the qumode picture, and it's what flips the cost model on its head.
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 880 220" width="100%" role="img" aria-labelledby="enc-title enc-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="enc-title">Four photonic encodings at a glance</title>
+    <desc id="enc-desc">Four small icons in a row showing dual-rail (two parallel waveguides with a photon in the upper rail), polarization (an arrow on the Bloch-style equator between horizontal and vertical), time-bin (two pulse envelopes separated in time), and continuous-variable (a Wigner blob in the x-p plane).</desc>
+
+    <g transform="translate(20 30)">
+      <text x="100" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Dual-rail</text>
+      <line x1="10" y1="60" x2="190" y2="60" stroke="currentColor" strokeWidth="2" />
+      <line x1="10" y1="110" x2="190" y2="110" stroke="currentColor" strokeWidth="2" />
+      <circle cx="80" cy="60" r="8" fill="var(--pillar-color, currentColor)" />
+      <text x="100" y="155" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">|1⟩<tspan dx="2">=</tspan> photon in upper rail</text>
+      <text x="100" y="172" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">|0⟩<tspan dx="2">=</tspan> photon in lower rail</text>
+    </g>
+
+    <line x1="230" y1="30" x2="230" y2="200" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(250 30)">
+      <text x="80" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Polarization</text>
+      <circle cx="80" cy="85" r="42" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <line x1="80" y1="43" x2="80" y2="127" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+      <line x1="38" y1="85" x2="122" y2="85" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+      <line x1="80" y1="85" x2="115" y2="65" stroke="var(--pillar-color, currentColor)" strokeWidth="2.5" markerEnd="url(#enc-arrow)" />
+      <text x="80" y="37" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">|V⟩</text>
+      <text x="130" y="89" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">|H⟩</text>
+      <text x="80" y="172" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">superposition</text>
+    </g>
+
+    <line x1="410" y1="30" x2="410" y2="200" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(430 30)">
+      <text x="100" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Time-bin</text>
+      <line x1="10" y1="100" x2="190" y2="100" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M 40 100 Q 55 60, 70 100" fill="none" stroke="var(--pillar-color, currentColor)" strokeWidth="2.5" />
+      <path d="M 130 100 Q 145 60, 160 100" fill="none" stroke="currentColor" strokeWidth="2.5" opacity="0.45" />
+      <text x="55" y="125" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">early</text>
+      <text x="145" y="125" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">late</text>
+      <text x="100" y="160" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">early bin = |0⟩,</text>
+      <text x="100" y="174" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">late bin = |1⟩</text>
+    </g>
+
+    <line x1="640" y1="30" x2="640" y2="200" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(660 30)">
+      <text x="100" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Continuous-variable</text>
+      <line x1="20" y1="120" x2="180" y2="120" stroke="currentColor" strokeWidth="1" />
+      <line x1="100" y1="40" x2="100" y2="160" stroke="currentColor" strokeWidth="1" />
+      <text x="180" y="135" fontSize="11" fill="currentColor" opacity="0.7">x</text>
+      <text x="105" y="46" fontSize="11" fill="currentColor" opacity="0.7">p</text>
+      <ellipse cx="130" cy="95" rx="26" ry="14" fill="var(--pillar-color, currentColor)" opacity="0.25" />
+      <ellipse cx="130" cy="95" rx="18" ry="9" fill="var(--pillar-color, currentColor)" opacity="0.55" />
+      <text x="100" y="180" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.7">quadratures in phase space</text>
+    </g>
+
+    <defs>
+      <marker id="enc-arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+        <path d="M0,0 L6,3 L0,6 z" fill="var(--pillar-color, currentColor)" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>The same photon, four ways. Dual-rail and polarization are flat two-level slices; time-bin trades flat for sequenced; CV abandons the slice entirely and uses the whole oscillator. The first three are qubits with a single photon as the carrier; the fourth is a qumode and counts photons.</figcaption>
+</figure>
+
 ## Mathematical structure
 
 A single mode of the field is, mathematically, just a quantum harmonic oscillator — a spring with a quantum mechanic's union card. Its algebra is generated by the bosonic annihilation and creation operators *a* and *a*<sup>†</sup>, satisfying [*a*, *a*<sup>†</sup>] = 1. The number operator n̂ = *a*<sup>†</sup>*a* has eigenstates |n⟩ for non-negative integers *n* — the Fock basis — which is just a fancy way of counting how many photons are in the mode.

--- a/site/content/photonics/ch02-phase-space.mdx
+++ b/site/content/photonics/ch02-phase-space.mdx
@@ -109,6 +109,57 @@ Five canonical examples build most of the intuition needed for later chapters:
   <figcaption>Wigner functions of four canonical CV states. The single-photon panel shows a ring with a darker central region indicating W(0, 0) &lt; 0; the other three are positive Gaussians.</figcaption>
 </figure>
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 250" width="100%" role="img" aria-labelledby="hom-title hom-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="hom-title">Balanced homodyne detection schematic</title>
+    <desc id="hom-desc">Signal mode and a strong local oscillator phase-shifted by theta enter a 50:50 beam splitter; the two output arms hit photodetectors whose difference current yields the rotated quadrature x_theta.</desc>
+
+    <g fill="currentColor">
+      <rect x="40" y="100" width="120" height="40" fill="none" stroke="currentColor" strokeWidth="1.4" rx="3" />
+      <text x="100" y="124" textAnchor="middle" fontSize="12">signal |ψ⟩</text>
+
+      <rect x="40" y="180" width="120" height="40" fill="none" stroke="currentColor" strokeWidth="1.4" rx="3" />
+      <text x="100" y="204" textAnchor="middle" fontSize="12">LO, phase θ</text>
+
+      <line x1="160" y1="120" x2="340" y2="120" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="160" y1="200" x2="340" y2="200" stroke="currentColor" strokeWidth="1.5" />
+
+      <g transform="translate(340 160)">
+        <rect x="-22" y="-22" width="44" height="44" fill="var(--pillar-color, currentColor)" fillOpacity="0.12" stroke="currentColor" strokeWidth="1.5" transform="rotate(45)" />
+        <text x="0" y="4" textAnchor="middle" fontSize="11">50:50</text>
+      </g>
+
+      <line x1="362" y1="138" x2="540" y2="80" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="362" y1="182" x2="540" y2="240" stroke="currentColor" strokeWidth="1.5" />
+
+      <g transform="translate(560 80)">
+        <circle cx="0" cy="0" r="18" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="-10" y1="0" x2="10" y2="0" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="-26" textAnchor="middle" fontSize="11">PD₊</text>
+      </g>
+      <g transform="translate(560 240)">
+        <circle cx="0" cy="0" r="18" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <line x1="-10" y1="0" x2="10" y2="0" stroke="currentColor" strokeWidth="1.5" />
+        <text x="0" y="38" textAnchor="middle" fontSize="11">PD₋</text>
+      </g>
+
+      <line x1="580" y1="80" x2="660" y2="80" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="580" y1="240" x2="660" y2="240" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="660" y1="80" x2="660" y2="240" stroke="currentColor" strokeWidth="1.5" />
+      <line x1="660" y1="160" x2="740" y2="160" stroke="var(--pillar-color, currentColor)" strokeWidth="2" markerEnd="url(#hd-arrow)" />
+      <text x="745" y="155" fontSize="13" fontWeight="600" fill="var(--pillar-color, currentColor)">i₊ − i₋</text>
+      <text x="745" y="172" fontSize="11" opacity="0.7">∝ x̂<tspan dy="2">θ</tspan></text>
+    </g>
+
+    <defs>
+      <marker id="hd-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+        <path d="M0,0 L7,3.5 L0,7 z" fill="var(--pillar-color, currentColor)" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>Balanced homodyne: a strong local oscillator at phase θ mixes with the weak signal on a 50:50 beam splitter; the difference photocurrent is proportional to the quadrature x̂<sub>θ</sub> = x̂ cos θ + p̂ sin θ. Sweeping θ samples every projection of W and a Radon inversion reconstructs the state.</figcaption>
+</figure>
+
 ## Measurement: homodyne, heterodyne, PNR
 
 Homodyne detection is a direct measurement of a single quadrature. The signal mode is mixed on a 50:50 beam splitter with a strong local oscillator of phase θ, and the difference photocurrent of the two output detectors is proportional to the rotated quadrature x̂<sub>θ</sub> = x̂ cos θ + p̂ sin θ. Sweeping θ and histogramming outcomes yields the marginals of W along every axis, from which W itself is reconstructed by inverse Radon transform — this is optical homodyne tomography, demonstrated since the early 1990s<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>.

--- a/site/content/photonics/ch03-gaussian-operations.mdx
+++ b/site/content/photonics/ch03-gaussian-operations.mdx
@@ -111,6 +111,70 @@ The full recipe for any Gaussian unitary on N modes is therefore: a Clements mes
   <figcaption>A four-mode rectangular MZI mesh in the Clements layout. Boxes are 2x2 beam splitters; filled dots are single-mode phase shifters. The accented path indicates one routing realized by a particular choice of mesh angles.</figcaption>
 </figure>
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 280" width="100%" role="img" aria-labelledby="prim-title prim-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="prim-title">The three Gaussian primitives</title>
+    <desc id="prim-desc">Three panels showing the three building blocks of Gaussian photonic circuits: a phase shifter applied to one mode, a beam splitter mixing two modes, and a squeezer driven by a pump that stretches the phase-space distribution along one quadrature.</desc>
+
+    <g transform="translate(20 30)">
+      <text x="120" y="0" textAnchor="middle" fontSize="14" fontWeight="600" fill="currentColor">Phase shifter</text>
+      <line x1="10" y1="80" x2="230" y2="80" stroke="currentColor" strokeWidth="2" />
+      <rect x="100" y="62" width="40" height="36" fill="var(--pillar-color, currentColor)" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.5" rx="3" />
+      <text x="120" y="86" textAnchor="middle" fontSize="13" fill="currentColor">φ</text>
+      <text x="35" y="74" fontSize="11" fill="currentColor" opacity="0.7">a</text>
+      <text x="210" y="74" fontSize="11" fill="currentColor" opacity="0.7">e<tspan dy="-3" fontSize="9">iφ</tspan><tspan dy="3"> </tspan>a</text>
+      <text x="120" y="135" textAnchor="middle" fontSize="12" fill="currentColor" opacity="0.8">single mode, 1 parameter</text>
+      <text x="120" y="155" textAnchor="middle" fontSize="11" fontStyle="italic" fill="currentColor" opacity="0.6">rotates (x, p) by angle φ</text>
+    </g>
+
+    <line x1="270" y1="30" x2="270" y2="240" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(290 30)">
+      <text x="120" y="0" textAnchor="middle" fontSize="14" fontWeight="600" fill="currentColor">Beam splitter</text>
+      <line x1="10" y1="55" x2="105" y2="55" stroke="currentColor" strokeWidth="2" />
+      <line x1="10" y1="115" x2="105" y2="115" stroke="currentColor" strokeWidth="2" />
+      <line x1="135" y1="55" x2="230" y2="55" stroke="currentColor" strokeWidth="2" />
+      <line x1="135" y1="115" x2="230" y2="115" stroke="currentColor" strokeWidth="2" />
+      <g transform="translate(120 85)">
+        <rect x="-18" y="-18" width="36" height="36" fill="var(--pillar-color, currentColor)" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.5" transform="rotate(45)" />
+        <text x="0" y="4" textAnchor="middle" fontSize="11" fill="currentColor">θ</text>
+      </g>
+      <text x="35" y="49" fontSize="11" fill="currentColor" opacity="0.7">a</text>
+      <text x="35" y="129" fontSize="11" fill="currentColor" opacity="0.7">b</text>
+      <text x="200" y="49" fontSize="11" fill="currentColor" opacity="0.7">a'</text>
+      <text x="200" y="129" fontSize="11" fill="currentColor" opacity="0.7">b'</text>
+      <text x="120" y="170" textAnchor="middle" fontSize="11" fontStyle="italic" fill="currentColor" opacity="0.6">a' = a cos θ − b sin θ</text>
+    </g>
+
+    <line x1="540" y1="30" x2="540" y2="240" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(560 30)">
+      <text x="120" y="0" textAnchor="middle" fontSize="14" fontWeight="600" fill="currentColor">Squeezer</text>
+      <line x1="10" y1="80" x2="230" y2="80" stroke="currentColor" strokeWidth="2" />
+      <rect x="85" y="55" width="70" height="50" fill="var(--pillar-color, currentColor)" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.5" rx="3" />
+      <text x="120" y="86" textAnchor="middle" fontSize="13" fill="currentColor">χ⁽²⁾</text>
+      <line x1="120" y1="30" x2="120" y2="55" stroke="var(--pillar-color, currentColor)" strokeWidth="2" markerEnd="url(#sq-arrow)" />
+      <text x="125" y="40" fontSize="11" fill="var(--pillar-color, currentColor)">pump</text>
+      <g transform="translate(60 200)">
+        <circle cx="0" cy="0" r="20" fill="currentColor" fillOpacity="0.2" />
+      </g>
+      <text x="60" y="245" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">vacuum</text>
+      <text x="120" y="200" textAnchor="middle" fontSize="14" fill="currentColor">→</text>
+      <g transform="translate(180 200)">
+        <ellipse cx="0" cy="0" rx="30" ry="9" fill="var(--pillar-color, currentColor)" fillOpacity="0.4" />
+      </g>
+      <text x="180" y="245" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">squeezed</text>
+    </g>
+
+    <defs>
+      <marker id="sq-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+        <path d="M0,0 L7,3.5 L0,7 z" fill="var(--pillar-color, currentColor)" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>The complete alphabet of single- and two-mode Gaussian operations. A phase shifter rotates the phase-space coordinates; a beam splitter mixes two modes by a real angle θ (plus optionally a relative phase); a squeezer driven by a χ<sup>(2)</sup> pump compresses one quadrature while stretching the other. Everything else in a Gaussian chip — displacement, two-mode squeezing, Bogoliubov rotations — is some composition of these three.</figcaption>
+</figure>
+
 ## Hardware today
 
 Silicon nitride and silicon-on-insulator MZI meshes are the current workhorses for the passive blocks, with thermo-optic or electro-optic phase shifters tuning the internal angles. Typical per-MZI insertion loss on SiN at telecom wavelengths sits in the 0.1–0.5 dB range in demonstrated devices, with thin-film lithium niobate offering faster modulation at comparable loss<sup className="fn-ref"><a href="#fn-3">[3]</a></sup>. Calibration of an N-mode mesh requires per-MZI characterization because fabrication variation drifts the splitter ratios away from 50:50.

--- a/site/content/photonics/ch04-non-gaussian.mdx
+++ b/site/content/photonics/ch04-non-gaussian.mdx
@@ -86,6 +86,85 @@ Success rates are stubbornly low — the heralding probability scales with |r|²
 
 Outside the optical domain, cat and GKP states have been prepared and stabilised in superconducting microwave cavities coupled to transmon ancillas, by groups at Yale and elsewhere.<sup className="fn-ref"><a href="#fn-7">[7]</a></sup> These demonstrations confirm the bosonic-code playbook works in hardware, but they do not transfer directly to room-temperature integrated optics: the microwave non-Gaussianity is supplied by the transmon's anharmonicity, which has no native optical analogue.
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 280" width="100%" role="img" aria-labelledby="zoo-title zoo-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="zoo-title">Four non-Gaussian Wigner functions side by side</title>
+    <desc id="zoo-desc">Four phase-space panels: a Fock state ring with a negative-valued center, an even cat state with two Gaussian lobes and interference fringes between them, a cubic-phase distortion of a vacuum Gaussian, and a GKP state shown as a grid of small Gaussian peaks.</desc>
+
+    <defs>
+      <radialGradient id="ng-fock" cx="0.5" cy="0.5" r="0.55">
+        <stop offset="0%" stopColor="var(--pillar-color, currentColor)" stopOpacity="0" />
+        <stop offset="40%" stopColor="var(--pillar-color, currentColor)" stopOpacity="0" />
+        <stop offset="55%" stopColor="var(--pillar-color, currentColor)" stopOpacity="0.55" />
+        <stop offset="100%" stopColor="var(--pillar-color, currentColor)" stopOpacity="0" />
+      </radialGradient>
+      <radialGradient id="ng-blob" cx="0.5" cy="0.5" r="0.5">
+        <stop offset="0%" stopColor="var(--pillar-color, currentColor)" stopOpacity="0.7" />
+        <stop offset="100%" stopColor="var(--pillar-color, currentColor)" stopOpacity="0" />
+      </radialGradient>
+    </defs>
+
+    <g transform="translate(20 30)">
+      <text x="90" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Fock |1⟩</text>
+      <rect x="20" y="15" width="140" height="140" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+      <line x1="20" y1="85" x2="160" y2="85" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <line x1="90" y1="15" x2="90" y2="155" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <circle cx="90" cy="85" r="55" fill="url(#ng-fock)" />
+      <circle cx="90" cy="85" r="14" fill="currentColor" fillOpacity="0.55" />
+      <text x="90" y="190" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.75">W(0,0) &lt; 0</text>
+      <text x="90" y="206" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.6">single photon</text>
+    </g>
+
+    <line x1="200" y1="30" x2="200" y2="260" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(220 30)">
+      <text x="90" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Cat |α⟩+|−α⟩</text>
+      <rect x="20" y="15" width="140" height="140" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+      <line x1="20" y1="85" x2="160" y2="85" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <line x1="90" y1="15" x2="90" y2="155" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <circle cx="50" cy="85" r="22" fill="url(#ng-blob)" />
+      <circle cx="130" cy="85" r="22" fill="url(#ng-blob)" />
+      <g stroke="currentColor" strokeWidth="1.2" opacity="0.45">
+        <line x1="80" y1="75" x2="100" y2="75" />
+        <line x1="75" y1="85" x2="105" y2="85" />
+        <line x1="80" y1="95" x2="100" y2="95" />
+      </g>
+      <text x="90" y="190" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.75">two lobes + fringes</text>
+      <text x="90" y="206" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.6">interference = negativity</text>
+    </g>
+
+    <line x1="400" y1="30" x2="400" y2="260" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(420 30)">
+      <text x="90" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">Cubic phase</text>
+      <rect x="20" y="15" width="140" height="140" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+      <line x1="20" y1="85" x2="160" y2="85" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <line x1="90" y1="15" x2="90" y2="155" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <path d="M 30 85 Q 60 30 90 85 T 150 85" fill="var(--pillar-color, currentColor)" fillOpacity="0.35" stroke="currentColor" strokeWidth="1" />
+      <path d="M 30 85 Q 60 130 90 85 T 150 85" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.45" strokeDasharray="3 3" />
+      <text x="90" y="190" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.75">e<tspan dy="-3" fontSize="9">iγx̂³</tspan></text>
+      <text x="90" y="206" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.6">deterministic but hard</text>
+    </g>
+
+    <line x1="600" y1="30" x2="600" y2="260" stroke="currentColor" strokeWidth="0.5" strokeDasharray="3 4" opacity="0.35" />
+
+    <g transform="translate(620 30)">
+      <text x="90" y="0" textAnchor="middle" fontSize="13" fontWeight="600" fill="currentColor">GKP</text>
+      <rect x="20" y="15" width="140" height="140" fill="none" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+      <line x1="20" y1="85" x2="160" y2="85" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <line x1="90" y1="15" x2="90" y2="155" stroke="currentColor" strokeWidth="0.6" opacity="0.4" />
+      <g fill="var(--pillar-color, currentColor)" fillOpacity="0.55">
+        <circle cx="50" cy="55" r="5" /><circle cx="90" cy="55" r="5" /><circle cx="130" cy="55" r="5" />
+        <circle cx="50" cy="85" r="5" /><circle cx="90" cy="85" r="6" /><circle cx="130" cy="85" r="5" />
+        <circle cx="50" cy="115" r="5" /><circle cx="90" cy="115" r="5" /><circle cx="130" cy="115" r="5" />
+      </g>
+      <text x="90" y="190" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.75">peak lattice</text>
+      <text x="90" y="206" textAnchor="middle" fontSize="11" fill="currentColor" opacity="0.6">built-in error correction</text>
+    </g>
+  </svg>
+  <figcaption>The non-Gaussian zoo. Fock states have a negative-valued center; even cat states have two Gaussian lobes with interference fringes between them; the cubic-phase gate skews the vacuum Gaussian into a non-quadratic surface; GKP states approximate a comb of delta peaks on a phase-space lattice. All four supply Wigner negativity — the resource Gaussian-only chips lack.</figcaption>
+</figure>
+
 ## Hardware today
 
 Heralded single photons from spontaneous parametric down-conversion and from semiconductor quantum dots: demonstrated and routinely used. Kitten states from photon subtraction on squeezed vacuum: demonstrated in many labs. Optical GKP states: proposed, simulated, and partially benchmarked, but no full end-to-end optical demonstration at the time of writing.

--- a/site/content/photonics/ch05-architectures.mdx
+++ b/site/content/photonics/ch05-architectures.mdx
@@ -144,6 +144,62 @@ A useful mental model: each fusion attempt is a bond on the resource-state graph
 
 **Quandela / Quix / boson-sampling lineage**. Quantum-dot single-photon sources (Quandela) or SPDC pair sources feeding programmable interferometer chips (Quix, others). Demonstrated: small-scale BosonSampling, variational photonic algorithms, six-photon GHZ generation. Proposed: integrated MBQC, near-term variational photonic computing, and modular linear-optical processors as building blocks for future fault-tolerant systems.
 
+<figure className="chapter-figure">
+  <svg viewBox="0 0 820 320" width="100%" role="img" aria-labelledby="cluster-title cluster-desc" xmlns="http://www.w3.org/2000/svg" style={{color: 'currentColor'}}>
+    <title id="cluster-title">A 2D cluster state and the MBQC measurement schedule</title>
+    <desc id="cluster-desc">A 6 by 4 lattice of circles connected by horizontal and vertical edges, representing entangled qubits. Time arrows from left to right show successive columns being measured, with measurement results feeding adaptively into the basis chosen for the next column.</desc>
+
+    <g transform="translate(40 50)">
+      <text x="360" y="-20" textAnchor="middle" fontSize="14" fontWeight="600" fill="currentColor">2D cluster state — entangle once, measure column by column</text>
+
+      <g stroke="currentColor" strokeWidth="1.2" opacity="0.55">
+        <line x1="40" y1="20" x2="680" y2="20" />
+        <line x1="40" y1="80" x2="680" y2="80" />
+        <line x1="40" y1="140" x2="680" y2="140" />
+        <line x1="40" y1="200" x2="680" y2="200" />
+
+        <line x1="40" y1="20" x2="40" y2="200" />
+        <line x1="160" y1="20" x2="160" y2="200" />
+        <line x1="280" y1="20" x2="280" y2="200" />
+        <line x1="400" y1="20" x2="400" y2="200" />
+        <line x1="520" y1="20" x2="520" y2="200" />
+        <line x1="640" y1="20" x2="640" y2="200" />
+      </g>
+
+      <g fill="var(--color-surface-card, white)" stroke="currentColor" strokeWidth="1.6">
+        <circle cx="40" cy="20" r="9" /><circle cx="160" cy="20" r="9" /><circle cx="280" cy="20" r="9" /><circle cx="400" cy="20" r="9" /><circle cx="520" cy="20" r="9" /><circle cx="640" cy="20" r="9" />
+        <circle cx="40" cy="80" r="9" /><circle cx="160" cy="80" r="9" /><circle cx="280" cy="80" r="9" /><circle cx="400" cy="80" r="9" /><circle cx="520" cy="80" r="9" /><circle cx="640" cy="80" r="9" />
+        <circle cx="40" cy="140" r="9" /><circle cx="160" cy="140" r="9" /><circle cx="280" cy="140" r="9" /><circle cx="400" cy="140" r="9" /><circle cx="520" cy="140" r="9" /><circle cx="640" cy="140" r="9" />
+        <circle cx="40" cy="200" r="9" /><circle cx="160" cy="200" r="9" /><circle cx="280" cy="200" r="9" /><circle cx="400" cy="200" r="9" /><circle cx="520" cy="200" r="9" /><circle cx="640" cy="200" r="9" />
+      </g>
+
+      <g fill="var(--pillar-color, currentColor)" fillOpacity="0.55">
+        <circle cx="40" cy="20" r="7" />
+        <circle cx="40" cy="80" r="7" />
+        <circle cx="40" cy="140" r="7" />
+        <circle cx="40" cy="200" r="7" />
+      </g>
+
+      <line x1="100" y1="245" x2="700" y2="245" stroke="currentColor" strokeWidth="1.2" markerEnd="url(#cl-arrow)" />
+      <text x="40" y="250" fontSize="11" fill="currentColor" opacity="0.75">measure</text>
+      <text x="710" y="250" fontSize="11" fill="currentColor" opacity="0.75">time →</text>
+
+      <text x="40" y="232" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">m₁</text>
+      <text x="160" y="232" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">m₂(m₁)</text>
+      <text x="280" y="232" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">m₃(m₁,₂)</text>
+
+      <text x="640" y="232" textAnchor="middle" fontSize="10" fill="currentColor" opacity="0.7">logical out</text>
+    </g>
+
+    <defs>
+      <marker id="cl-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+        <path d="M0,0 L7,3.5 L0,7 z" fill="currentColor" />
+      </marker>
+    </defs>
+  </svg>
+  <figcaption>A two-dimensional cluster state: nodes are qubits, edges are CZ entanglement bonds. The computation proceeds by measuring columns from left to right; each measurement basis depends adaptively on outcomes already gathered to the left. Logical information flows horizontally; gates are realized by the pattern of measurement bases. The leftmost column highlighted in pillar colour is the next slated for measurement.</figcaption>
+</figure>
+
 ## The loss problem
 
 Per-component loss budgets dominate every scaling estimate. Representative numbers for current silicon photonic platforms at telecom wavelengths: chip-to-fiber coupling 0.5–1 dB per facet, on-chip waveguide propagation around 0.1 dB/cm, on-chip components (MZIs, filters) a few tenths of a dB each, and superconducting nanowire single-photon detector efficiency around 95%. End-to-end loss of 1–3 dB per photon is typical for current integrated chips, corresponding to 20–50% per-photon survival probabilities.

--- a/site/styles/globals.css
+++ b/site/styles/globals.css
@@ -1377,8 +1377,129 @@ main[data-pillar="code-int"] {
   color: var(--color-text-footnote);
 }
 
+.chapter-main {
+  max-width: 1280px;
+}
+
+.chapter-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--spacing-8);
+  margin-top: var(--spacing-5);
+}
+
+@media (min-width: 1024px) {
+  .chapter-layout {
+    grid-template-columns: 220px minmax(0, 1fr);
+    gap: var(--spacing-10);
+  }
+}
+
+.chapter-sidebar {
+  display: none;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+@media (min-width: 1024px) {
+  .chapter-sidebar {
+    display: block;
+    position: sticky;
+    top: var(--spacing-5);
+    align-self: start;
+    max-height: calc(100vh - var(--spacing-8));
+    overflow-y: auto;
+    padding-right: var(--spacing-3);
+    border-right: 1px solid var(--color-border-hair);
+  }
+}
+
+.chapter-sidebar__book {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--pillar-color, var(--color-text-muted));
+  text-decoration: none;
+  margin-bottom: var(--spacing-4);
+}
+
+.chapter-sidebar__book:hover {
+  color: var(--color-text-body);
+}
+
+.chapter-sidebar__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.chapter-sidebar__item {
+  padding: 0;
+}
+
+.chapter-sidebar__link {
+  display: grid;
+  grid-template-columns: 1.75rem 1fr;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-2);
+  border-radius: 4px;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  line-height: 1.3;
+}
+
+.chapter-sidebar__link:hover {
+  color: var(--color-text-body);
+  background: var(--color-surface-card);
+}
+
+.chapter-sidebar__num {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-text-footnote);
+  padding-top: 0.15rem;
+}
+
+.chapter-sidebar__title {
+  font-size: 0.88rem;
+}
+
+.chapter-sidebar__item.is-current .chapter-sidebar__link {
+  color: var(--color-text-body);
+  background: var(--color-surface-card);
+}
+
+.chapter-sidebar__item.is-current .chapter-sidebar__num {
+  color: var(--pillar-color);
+}
+
+.chapter-sidebar__item.is-current .chapter-sidebar__title {
+  font-weight: 600;
+}
+
 .chapter-article {
+  max-width: 960px;
+  min-width: 0;
+}
+
+.chapter-article > p,
+.chapter-article > ul,
+.chapter-article > ol,
+.chapter-article > blockquote,
+.chapter-article > .chapter-lede,
+.chapter-article > .footnotes {
   max-width: 68ch;
+}
+
+.chapter-article > h1,
+.chapter-article > h2,
+.chapter-article > h3 {
+  max-width: 72ch;
 }
 
 .chapter-article h1 {


### PR DESCRIPTION
## Summary
This PR enhances the chapter reading experience by adding a persistent sidebar navigation component and embedding several new SVG figures throughout the code-intelligence and photonics books.

## Key Changes

### Navigation & Layout
- **New `ChapterSidebar` component** (`site/components/ChapterSidebar.tsx`): A reusable sidebar that displays the book title and chapter list with the current chapter highlighted. Includes responsive design that hides on mobile and becomes sticky on desktop (1024px+).
- **Updated chapter page layouts** for both code-intelligence and photonics: Wrapped article content in a new `.chapter-layout` grid that positions the sidebar alongside the main content.
- **CSS grid system** (`site/styles/globals.css`): Added `.chapter-layout`, `.chapter-main`, and comprehensive `.chapter-sidebar__*` styles for responsive two-column layout with proper spacing and visual hierarchy.

### Content Enhancements
Added 8 new inline SVG figures across both books:
- **Code Intelligence**: 
  - CST vs AST comparison (ch02)
  - AST tree diagram for assignment expression (ch01)
  - Constant-propagation lattice (ch03)
  - Embedding space with query vectors (ch05)
  - LSP request/response flow (ch04)
- **Photonics**:
  - Four photonic encodings (ch01)
  - Three Gaussian primitives (ch03)
  - Non-Gaussian Wigner functions zoo (ch04)
  - 2D cluster state and MBQC measurement schedule (ch05)
  - Balanced homodyne detection schematic (ch02)

### Styling Updates
- Extended `.chapter-article` max-width to 960px with nested content constraints (68ch for prose, 72ch for headings)
- Added responsive sidebar styling with hover states, current-page highlighting, and proper typography hierarchy
- Integrated pillar color theming throughout sidebar and figure elements

## Implementation Details
- All SVG figures use semantic `aria-labelledby` and `aria-describedby` for accessibility
- Sidebar uses CSS custom properties (`--pillar-color`, `--color-*`) for theme consistency
- Responsive breakpoint at 1024px ensures mobile-friendly experience
- Chapter navigation uses Next.js `Link` component with `aria-current="page"` for current page indication

https://claude.ai/code/session_01V1fx51Jf6WF7x4bBwsgaDF