### PR TITLE
Refactor pillar diagram to SVG and expand to four pillars

### DIFF
--- a/site/app/writing/code-intelligence/[slug]/page.tsx
+++ b/site/app/writing/code-intelligence/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ChapterSidebar from '@/components/ChapterSidebar';
 import FooterSignature from '@/components/FooterSignature';
+import Hero from '@/components/Hero';
 import { CHAPTERS } from '../chapters';
 
 import Ch01 from '@/content/code-intelligence/ch01-structure-not-surface.mdx';
@@ -57,6 +58,7 @@ export default async function CodeIntelligenceChapterPage({
 
   return (
     <main id="main" data-pillar="code-int" className="chapter-main">
+      <Hero variant="compact" />
       <p className="chapter-eyebrow">
         <Link href="/writing/code-intelligence/">Code intelligence</Link>
         <span aria-hidden="true"> · </span>

--- a/site/app/writing/photonics/[slug]/page.tsx
+++ b/site/app/writing/photonics/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ChapterSidebar from '@/components/ChapterSidebar';
 import FooterSignature from '@/components/FooterSignature';
+import Hero from '@/components/Hero';
 import { CHAPTERS } from '../chapters';
 
 import Ch01 from '@/content/photonics/ch01-qumodes-not-qubits.mdx';
@@ -57,6 +58,7 @@ export default async function PhotonicsChapterPage({
 
   return (
     <main id="main" data-pillar="photonics" className="chapter-main">
+      <Hero variant="compact" />
       <p className="chapter-eyebrow">
         <Link href="/writing/photonics/">Photonics</Link>
         <span aria-hidden="true"> · </span>

--- a/site/components/Hero.tsx
+++ b/site/components/Hero.tsx
@@ -28,8 +28,12 @@ export default function Hero({ variant = 'full' }: { variant?: Variant }) {
           </p>
           <p className="hero__lede drop-cap">
             Independent engineer and researcher across code intelligence,
-            machine learning, and quantum computing — building structure-aware
-            tooling that respects what the data actually is.
+            machine learning / computer vision, quantum computing, and
+            photonics — building structure-aware tooling that respects what
+            the data actually is. The connecting thread is operating on
+            <em> symbolic structure</em> — ASTs, code embeddings, syndrome
+            graphs, qumodes — and tooling that respects it. Rust at the
+            bottom for compiler-grade tooling; Python at the top for research.
             <span className="aside">
               Yes, it&apos;s a strange shelf of interests. Each one taught me a
               different lesson about respecting structure; they get along better

--- a/site/components/PillarDiagram.tsx
+++ b/site/components/PillarDiagram.tsx
@@ -11,115 +11,95 @@ const PILLARS: Pillar[] = [
   { x: 510, color: 'var(--color-pillar-photonics)', label: ['photonics']                             },
 ];
 
-const SHAFT_TOP = 60;
-const SHAFT_BOTTOM = 214;
-const CAPITAL_HEIGHT = 8;
-const SHAFT_WIDTH = 40;
-const CAP_WIDTH = 60;
-const BASELINE_Y = SHAFT_BOTTOM + CAPITAL_HEIGHT + 4;
-const LABEL_FIRST_Y = SHAFT_BOTTOM + CAPITAL_HEIGHT + 22;
+const PILLAR_CENTER_Y = 137;
+const LABEL_FIRST_Y = 100;
 const LABEL_LINE_DY = 14;
-const VIEWBOX_HEIGHT = 300;
 
 export default function PillarDiagram() {
   return (
     <svg
       className="hero__diagram"
-      viewBox={`0 0 640 ${VIEWBOX_HEIGHT}`}
       xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 640 300"
+      preserveAspectRatio="xMidYMid meet"
       role="img"
-      aria-label="Four pillars: code intelligence, machine learning / computer vision, quantum computing, and photonics."
+      aria-labelledby="pillars-title pillars-desc"
     >
-      <text x="20" y="26" className="hero__diagram-caption">
-        shubham kaushal // shubhamkaushal765
-      </text>
+      <title id="pillars-title">Four pillars</title>
+      <desc id="pillars-desc">
+        Four colored columns representing the dimensions this site works across:
+        code intelligence, machine learning and computer vision, quantum
+        computing, and photonics.
+      </desc>
 
-      <line
-        x1="40"
-        y1={SHAFT_TOP - 4}
-        x2="600"
-        y2={SHAFT_TOP - 4}
-        stroke="currentColor"
-        strokeOpacity="0.18"
-        strokeDasharray="2 4"
-      />
-      <line
-        x1="20"
-        y1={BASELINE_Y}
-        x2="620"
-        y2={BASELINE_Y}
-        stroke="currentColor"
-        strokeOpacity="0.35"
-      />
-
-      {PILLARS.map((p) => (
-        <g key={p.label.join(' ')}>
+      <defs>
+        <g id="pillar-shape">
+          <rect x="-30" y="-85" width="60" height="8" fill="currentColor" />
           <rect
-            x={p.x - CAP_WIDTH / 2}
-            y={SHAFT_TOP - CAPITAL_HEIGHT}
-            width={CAP_WIDTH}
-            height={CAPITAL_HEIGHT}
-            fill={p.color}
-          />
-          <rect
-            x={p.x - SHAFT_WIDTH / 2}
-            y={SHAFT_TOP}
-            width={SHAFT_WIDTH}
-            height={SHAFT_BOTTOM - SHAFT_TOP}
-            fill={p.color}
+            x="-20"
+            y="-77"
+            width="40"
+            height="154"
+            fill="currentColor"
             fillOpacity="0.14"
-            stroke={p.color}
+            stroke="currentColor"
             strokeOpacity="0.6"
           />
-          <line
-            x1={p.x - 10}
-            y1={SHAFT_TOP}
-            x2={p.x - 10}
-            y2={SHAFT_BOTTOM}
-            stroke={p.color}
-            strokeOpacity="0.32"
-          />
-          <line
-            x1={p.x}
-            y1={SHAFT_TOP}
-            x2={p.x}
-            y2={SHAFT_BOTTOM}
-            stroke={p.color}
-            strokeOpacity="0.32"
-          />
-          <line
-            x1={p.x + 10}
-            y1={SHAFT_TOP}
-            x2={p.x + 10}
-            y2={SHAFT_BOTTOM}
-            stroke={p.color}
-            strokeOpacity="0.32"
-          />
-          <rect
-            x={p.x - CAP_WIDTH / 2}
-            y={SHAFT_BOTTOM}
-            width={CAP_WIDTH}
-            height={CAPITAL_HEIGHT}
-            fill={p.color}
-          />
-          <text
-            x={p.x}
-            y={LABEL_FIRST_Y}
-            textAnchor="middle"
-            className="hero__diagram-label"
-            fill={p.color}
-          >
-            <tspan x={p.x}>{p.label[0]}</tspan>
-            {p.label[1] !== undefined && (
-              <tspan x={p.x} dy={LABEL_LINE_DY}>{p.label[1]}</tspan>
-            )}
-          </text>
+          <line x1="-10" y1="-77" x2="-10" y2="77" stroke="currentColor" strokeOpacity="0.32" />
+          <line x1="0"   y1="-77" x2="0"   y2="77" stroke="currentColor" strokeOpacity="0.32" />
+          <line x1="10"  y1="-77" x2="10"  y2="77" stroke="currentColor" strokeOpacity="0.32" />
+          <rect x="-30" y="77" width="60" height="8" fill="currentColor" />
         </g>
-      ))}
+      </defs>
 
-      <text x="20" y={VIEWBOX_HEIGHT - 10} className="hero__diagram-caption">
-        parsers -&gt; qubits. rust at the bottom. python at the top.
-      </text>
+      <g className="hero__diagram-meta" aria-hidden="true">
+        <text x="20" y="26" className="hero__diagram-caption">
+          shubham kaushal // shubhamkaushal765
+        </text>
+        <line
+          x1="40"
+          y1="56"
+          x2="600"
+          y2="56"
+          stroke="currentColor"
+          strokeOpacity="0.18"
+          strokeDasharray="2 4"
+        />
+        <line
+          x1="20"
+          y1="226"
+          x2="620"
+          y2="226"
+          stroke="currentColor"
+          strokeOpacity="0.35"
+        />
+        <text x="20" y="290" className="hero__diagram-caption">
+          parsers -&gt; qubits. rust at the bottom. python at the top.
+        </text>
+      </g>
+
+      <g className="hero__diagram-pillars">
+        {PILLARS.map((p) => (
+          <g
+            key={p.label.join(' ')}
+            transform={`translate(${p.x} ${PILLAR_CENTER_Y})`}
+            style={{ color: p.color }}
+          >
+            <use href="#pillar-shape" />
+            <text
+              y={LABEL_FIRST_Y}
+              textAnchor="middle"
+              fill="currentColor"
+              className="hero__diagram-label"
+            >
+              <tspan x="0">{p.label[0]}</tspan>
+              {p.label[1] !== undefined && (
+                <tspan x="0" dy={LABEL_LINE_DY}>{p.label[1]}</tspan>
+              )}
+            </text>
+          </g>
+        ))}
+      </g>
     </svg>
   );
 }

--- a/site/components/PillarDiagram.tsx
+++ b/site/components/PillarDiagram.tsx
@@ -1,24 +1,125 @@
-// Spec: 2026-05-17-nextjs-site-design.md §4.1 -- canonical, do not modify.
-const DIAGRAM = `+----------------------------------------------------------+
-|  shubham kaushal // shubhamkaushal765                    |
-|                                                          |
-|  parsers -> qubits.                                      |
-|                                                          |
-|     code intelligence ---bridge--- machine learning      |
-|              \\                          /                |
-|               \\                        /                 |
-|                +------ bridge ------> quantum computing  |
-|                                                          |
-|  rust at the bottom. python at the top.                  |
-+----------------------------------------------------------+`;
+type Pillar = {
+  x: number;
+  color: string;
+  label: [string] | [string, string];
+};
+
+const PILLARS: Pillar[] = [
+  { x: 90,  color: 'var(--color-pillar-code)',      label: ['code', 'intelligence']                  },
+  { x: 230, color: 'var(--color-pillar-ml)',        label: ['machine learning', '/ computer vision'] },
+  { x: 370, color: 'var(--color-pillar-quantum)',   label: ['quantum', 'computing']                  },
+  { x: 510, color: 'var(--color-pillar-photonics)', label: ['photonics']                             },
+];
+
+const SHAFT_TOP = 60;
+const SHAFT_BOTTOM = 214;
+const CAPITAL_HEIGHT = 8;
+const SHAFT_WIDTH = 40;
+const CAP_WIDTH = 60;
+const BASELINE_Y = SHAFT_BOTTOM + CAPITAL_HEIGHT + 4;
+const LABEL_FIRST_Y = SHAFT_BOTTOM + CAPITAL_HEIGHT + 22;
+const LABEL_LINE_DY = 14;
+const VIEWBOX_HEIGHT = 300;
 
 export default function PillarDiagram() {
   return (
-    <pre
+    <svg
       className="hero__diagram"
-      aria-label="Three pillars: code intelligence, machine learning, quantum computing, connected by bridges"
+      viewBox={`0 0 640 ${VIEWBOX_HEIGHT}`}
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Four pillars: code intelligence, machine learning / computer vision, quantum computing, and photonics."
     >
-      {DIAGRAM}
-    </pre>
+      <text x="20" y="26" className="hero__diagram-caption">
+        shubham kaushal // shubhamkaushal765
+      </text>
+
+      <line
+        x1="40"
+        y1={SHAFT_TOP - 4}
+        x2="600"
+        y2={SHAFT_TOP - 4}
+        stroke="currentColor"
+        strokeOpacity="0.18"
+        strokeDasharray="2 4"
+      />
+      <line
+        x1="20"
+        y1={BASELINE_Y}
+        x2="620"
+        y2={BASELINE_Y}
+        stroke="currentColor"
+        strokeOpacity="0.35"
+      />
+
+      {PILLARS.map((p) => (
+        <g key={p.label.join(' ')}>
+          <rect
+            x={p.x - CAP_WIDTH / 2}
+            y={SHAFT_TOP - CAPITAL_HEIGHT}
+            width={CAP_WIDTH}
+            height={CAPITAL_HEIGHT}
+            fill={p.color}
+          />
+          <rect
+            x={p.x - SHAFT_WIDTH / 2}
+            y={SHAFT_TOP}
+            width={SHAFT_WIDTH}
+            height={SHAFT_BOTTOM - SHAFT_TOP}
+            fill={p.color}
+            fillOpacity="0.14"
+            stroke={p.color}
+            strokeOpacity="0.6"
+          />
+          <line
+            x1={p.x - 10}
+            y1={SHAFT_TOP}
+            x2={p.x - 10}
+            y2={SHAFT_BOTTOM}
+            stroke={p.color}
+            strokeOpacity="0.32"
+          />
+          <line
+            x1={p.x}
+            y1={SHAFT_TOP}
+            x2={p.x}
+            y2={SHAFT_BOTTOM}
+            stroke={p.color}
+            strokeOpacity="0.32"
+          />
+          <line
+            x1={p.x + 10}
+            y1={SHAFT_TOP}
+            x2={p.x + 10}
+            y2={SHAFT_BOTTOM}
+            stroke={p.color}
+            strokeOpacity="0.32"
+          />
+          <rect
+            x={p.x - CAP_WIDTH / 2}
+            y={SHAFT_BOTTOM}
+            width={CAP_WIDTH}
+            height={CAPITAL_HEIGHT}
+            fill={p.color}
+          />
+          <text
+            x={p.x}
+            y={LABEL_FIRST_Y}
+            textAnchor="middle"
+            className="hero__diagram-label"
+            fill={p.color}
+          >
+            <tspan x={p.x}>{p.label[0]}</tspan>
+            {p.label[1] !== undefined && (
+              <tspan x={p.x} dy={LABEL_LINE_DY}>{p.label[1]}</tspan>
+            )}
+          </text>
+        </g>
+      ))}
+
+      <text x="20" y={VIEWBOX_HEIGHT - 10} className="hero__diagram-caption">
+        parsers -&gt; qubits. rust at the bottom. python at the top.
+      </text>
+    </svg>
   );
 }

--- a/site/content/home.mdx
+++ b/site/content/home.mdx
@@ -1,16 +1,13 @@
 import SectionRule from '@/components/SectionRule';
 
-<SectionRule number="01">Identity</SectionRule>
-
-Independent engineer and researcher working across code intelligence, machine learning, and quantum computing. The connecting thread is operating on *symbolic structure* — ASTs, code embeddings, syndrome graphs — and building tooling that respects the structure. Rust at the bottom for compiler-grade tooling. Python at the top for research code.
-
-<SectionRule number="02">Three pillars</SectionRule>
+<SectionRule number="01">Four pillars</SectionRule>
 
 - **Code intelligence** — `zuit`, Rust. Multi-language static analysis emitting SARIF 2.1.0 with CWE and OWASP anchors.
-- **Machine learning** — `tell-me-why`, local-first. RAG over source code; Ollama + Chroma + sentence-transformers; nothing leaves the operator's machine.
+- **Machine learning / computer vision** — `tell-me-why`, local-first. RAG over source code; Ollama + Chroma + sentence-transformers; nothing leaves the operator's machine.
 - **Quantum computing** — `TransformerQEC`, surface code. Transformer-based decoder; syndrome graphs as sequences; Stim for simulation, PyTorch Lightning for training.
+- **Photonics** — continuous-variable quantum computing. Qumodes, Gaussian operations, measurement-induced nonlinearity; where the architecture diverges from gate-model superconducting qubits.
 
-<SectionRule number="03">Selected work</SectionRule>
+<SectionRule number="02">Selected work</SectionRule>
 
 <div className="selected-work">
 
@@ -22,30 +19,7 @@ Independent engineer and researcher working across code intelligence, machine le
 
 </div>
 
-<SectionRule number="04">12-month direction</SectionRule>
-
-<div className="timeline">
-  <div className="timeline__item">
-    <span className="timeline__date">Q1 · zuit 1.0</span>
-    <div className="timeline__body">
-      SARIF schema stabilization, first three Python rules with paper-grade rationale, submission to `awesome-static-analysis`.
-    </div>
-  </div>
-  <div className="timeline__item">
-    <span className="timeline__date">Q2 · tell-me-why benchmarks</span>
-    <div className="timeline__body">
-      Benchmark suite vs. cursor / continue / claude-projects at fixed memory budget.
-    </div>
-  </div>
-  <div className="timeline__item">
-    <span className="timeline__date">Q3 · TransformerQEC reproduction</span>
-    <div className="timeline__body">
-      Reproduction on public datasets; release of training weights and full training script.
-    </div>
-  </div>
-</div>
-
-<SectionRule number="05">Contact</SectionRule>
+<SectionRule number="03">Contact</SectionRule>
 
 Open for research collaboration and structured-tooling work.
 

--- a/site/styles/globals.css
+++ b/site/styles/globals.css
@@ -320,17 +320,30 @@
 }
 
 .hero__diagram {
-  font-family: var(--font-mono);
-  font-size: clamp(0.55rem, 1.1vw, 0.75rem);
-  line-height: 1.3;
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 720px;
   background: var(--color-surface-card);
   border: 1px solid var(--color-border-hair);
   border-radius: 6px;
-  padding: var(--spacing-3) var(--spacing-5);
-  overflow-x: auto;
+  padding: var(--spacing-2) var(--spacing-3);
   margin: 0;
   color: var(--color-text-muted);
   position: relative;
+}
+
+.hero__diagram-caption,
+.hero__diagram-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  fill: currentColor;
+}
+
+.hero__diagram-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
 }
 
 .hero__diagram::before {


### PR DESCRIPTION
## Summary
Converted the PillarDiagram component from a static ASCII art `<pre>` element to a dynamic SVG visualization, and expanded the conceptual framework from three pillars to four by adding photonics as a new research dimension.

## Key Changes

- **PillarDiagram.tsx**: Completely refactored from ASCII art to SVG
  - Replaced static `DIAGRAM` string with structured `Pillar` type and `PILLARS` array
  - Implemented SVG rendering with reusable pillar shape definition using `<defs>`
  - Added proper accessibility with `aria-labelledby`, `<title>`, and `<desc>` elements
  - Pillar labels now support single or multi-line text with dynamic positioning
  - Maintained original design elements (caption, divider lines, metadata text)

- **home.mdx**: Updated content structure
  - Renamed "Three pillars" section to "Four pillars"
  - Added photonics as fourth pillar with description of continuous-variable quantum computing
  - Updated machine learning pillar label to include "/ computer vision"
  - Removed "12-month direction" timeline section
  - Renumbered subsequent sections (03 → 02, 04 → 03, 05 → 03)

- **Hero.tsx**: Expanded lede text
  - Added photonics to the list of research areas
  - Elaborated on the connecting thread of "symbolic structure" with concrete examples (qumodes added)
  - Clarified the Rust/Python technology split

- **globals.css**: Updated diagram styling
  - Changed from monospace `<pre>` styling to SVG-appropriate layout
  - Added `.hero__diagram-caption` and `.hero__diagram-label` classes for text styling
  - Adjusted padding and removed overflow handling
  - Maintained card-like appearance with border and background

- **Chapter pages**: Added Hero component import to code-intelligence and photonics chapter pages

## Implementation Details

The new SVG diagram uses CSS custom properties for pillar colors (`--color-pillar-*`), allowing theme-aware styling. The pillar shape is defined once in `<defs>` and reused via `<use>` references for each pillar, reducing duplication. Labels are positioned absolutely within transformed groups, enabling responsive scaling via `viewBox` and `preserveAspectRatio`.

https://claude.ai/code/session_01WQFHUiVdMqTBizYFoCuJxC