### PR TITLE
Add retention scaffolding and running example to BO book

### DIFF
--- a/.agent/writing-strategy.md
+++ b/.agent/writing-strategy.md
@@ -168,4 +168,4 @@ section. Currently published books:
   RAG/embedding pipeline (EI over embedding-model search spaces), the qubit
   calibration work (gate-pulse BO), and core ML infrastructure. Fits narrative
   theme 1 (structured artifact reasoning) and theme 2 (local-first
-  infrastructure).
+  infrastructure). The book is written to a retention-oriented teaching structure: each chapter anchors on a single sustained mental-model metaphor, threads one running example (tuning the `tell-me-why` retrieval pipeline's indexing chunk size), and introduces intuition before equations. Every chapter ends with "Check your understanding" and "What to remember" blocks placed before the closing notes section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,14 @@ To add one, create the following files and registrations:
 - Inline SVG figures use `currentColor` and `var(--pillar-color, currentColor)`
   for accent strokes, with unique chapter-prefixed `id` attributes.
 - Citations appear as footnotes (not naked inline links).
+- Retention scaffolding (reference implementation: `bayesian-optimization`):
+  - Open each chapter with a memorable mental model introduced as "A useful mental model: ..." (a single sustained metaphor carried across all chapters).
+  - Thread a single running example through all five chapters.
+  - Chapters 2-5 open with a one-sentence bridge: "In Chapter NN we ...; this chapter answers the question that left open: ..."
+  - Intuition-before-equation: include a short numeric walkthrough before any key equation (GP posterior, Expected Improvement, etc.).
+  - End each chapter with two retention blocks in this order, placed BEFORE the final `## Notes` section: `## Check your understanding` (3 reasoning questions) and `## What to remember` (bold one-sentence summary, 3-bullet list, bold `Key insight:` line). `## Notes` must remain the last section.
+  - Include exactly one `<p className="aside">` memory hook per chapter.
+  - Use plain Markdown plus the existing `.aside` primitive only. No new CSS, no new components, no new SVG.
 
 ## Adding a new repo to the profile
 

--- a/site/app/writing/bayesian-optimization/chapters.ts
+++ b/site/app/writing/bayesian-optimization/chapters.ts
@@ -13,7 +13,7 @@ export const CHAPTERS: Chapter[] = [
     title: 'Why Bayesian optimization? Sample efficiency, not scale.',
     summary:
       'Training a neural network, running a lab assay, and calibrating a qubit share one property: each evaluation is expensive and you cannot afford many. Bayesian optimization formalizes the surrogate-plus-acquisition loop that gets the most information per query.',
-    reading: '9 min',
+    reading: '12 min',
   },
   {
     number: '02',
@@ -21,7 +21,7 @@ export const CHAPTERS: Chapter[] = [
     title: 'Gaussian processes: a surrogate that quantifies its own doubt.',
     summary:
       'A GP places a prior over functions and updates it with observations to produce a posterior mean and variance at every untried point. The kernel encodes prior beliefs about smoothness; the marginal likelihood tunes it automatically.',
-    reading: '11 min',
+    reading: '14 min',
   },
   {
     number: '03',
@@ -29,7 +29,7 @@ export const CHAPTERS: Chapter[] = [
     title: 'Acquisition functions: turning uncertainty into the next query.',
     summary:
       'Expected improvement, probability of improvement, GP-UCB, and Thompson sampling each define a different policy for trading off exploration against exploitation. Optimizing the acquisition is cheap relative to the black-box objective.',
-    reading: '10 min',
+    reading: '13 min',
   },
   {
     number: '04',
@@ -37,7 +37,7 @@ export const CHAPTERS: Chapter[] = [
     title: 'The loop in practice: priors, noise, and where it breaks.',
     summary:
       'Kernel and length-scale priors matter more than most tutorials admit. Noisy observations, input warping, high-dimensional search spaces, and batch parallelism each require specific design choices that the basic loop glosses over.',
-    reading: '12 min',
+    reading: '15 min',
   },
   {
     number: '05',
@@ -45,6 +45,6 @@ export const CHAPTERS: Chapter[] = [
     title: 'Bayesian optimization in the wild: hyperparameters and qubit calibration.',
     summary:
       'Two worked domains: tuning ML embedding models (the RAG pipeline from the code-intelligence pillar) and qubit gate calibration (RB, T1, T2, gate tomography) framed as sequential black-box optimization. Reproducibility via seeds and fixtures.',
-    reading: '13 min',
+    reading: '16 min',
   },
 ];

--- a/site/content/bayesian-optimization/ch01-why-bayesian-optimization.mdx
+++ b/site/content/bayesian-optimization/ch01-why-bayesian-optimization.mdx
@@ -4,12 +4,16 @@ export const meta = {
   title: 'Why Bayesian optimization? Sample efficiency, not scale.',
   summary:
     'Training a neural network, running a lab assay, and calibrating a qubit share one property: each evaluation is expensive and you cannot afford many. Bayesian optimization formalizes the surrogate-plus-acquisition loop that gets the most information per query.',
-  reading: '9 min',
+  reading: '12 min',
 };
 
 # Why Bayesian optimization? Sample efficiency, not scale.
 
-<p className="chapter-lede">Training a neural network, running a wet-lab assay, and calibrating a qubit gate each have the same structural property: one evaluation is expensive, the number of evaluations is small, and the objective has no closed-form gradient. Bayesian optimization addresses this class of problem directly. It maintains a probabilistic model of the objective -- the surrogate -- and uses that model to decide where to evaluate next, extracting the most information from every call to the black box.</p>
+<p className="chapter-lede">Training a neural network, running a wet-lab assay, and calibrating a qubit gate each have the same structural property: one evaluation is expensive, the number of evaluations is small, and the objective has no closed-form gradient. Bayesian optimization addresses this class of problem directly. It keeps a probabilistic model of the objective, the surrogate, and uses that model to decide where to evaluate next. The goal is to extract the most information from every call to the black box.</p>
+
+A useful mental model: Bayesian optimization is a treasure hunter on a huge foggy island who is allowed only a few digs. Every dig is costly, the map starts blank, and the only way to win is to let each dig sharpen the guess about where to dig next. The rest of this book is about building that map and choosing those digs well.
+
+<p className="aside">A treasure hunter with infinite digs does not need a strategy. Bayesian optimization only exists because the digs run out.</p>
 
 ## The expensive-evaluation regime
 
@@ -18,6 +22,8 @@ An evaluation is expensive when it takes seconds to hours of wall time, consumes
 Grid search does not solve this problem. It evaluates a Cartesian product of parameter values, most of which lie in regions the objective is already known to be poor. Random search is an improvement -- it avoids the curse of the grid corners -- but it ignores everything it has already learned. Each random trial is drawn from the same prior regardless of what previous trials returned.
 
 The regime that Bayesian optimization targets is roughly 10 to 500 evaluations of a function that takes more than a few seconds per call and has no accessible gradient. Below that budget, random search or a single educated guess is often enough. Above it, the surrogate overhead becomes less justified and cheaper alternatives (evolutionary methods, quasi-random designs) compete more favorably.
+
+A running example makes the regime concrete. Behind `tell-me-why`, the local-first RAG pipeline, sits one knob worth tuning: the indexing chunk size, a single continuous value from 64 to 2048 tokens. Each setting is scored by recall@10 on a fixed held-out query set, and each trial reindexes the corpus and reruns the benchmark, about 8 minutes on a GPU. The budget is roughly 25 trials, which is squarely the expensive-evaluation regime where guessing blindly wastes the few digs you have.
 
 ## The surrogate-plus-acquisition loop
 
@@ -91,6 +97,22 @@ Jones, Schonlau, and Welch formalized this loop in 1998 under the name Efficient
 The black-box objective is typically not differentiable in any accessible way. The training loss of a model as a function of its hyperparameters is not differentiable because the training run is a discrete, stochastic process. A lab assay returns a scalar measurement with no gradient attached. Even when an automatic differentiation framework could in principle compute a gradient through the simulation, the cost of that computation equals or exceeds the cost of the forward evaluation itself -- which doubles the budget rather than saving it.
 
 Finite-difference gradient estimation is one escape route, but it requires at least one extra evaluation per input dimension. A ten-dimensional hyperparameter space demands eleven evaluations to estimate a single gradient, consuming the entire sample budget in one step. The surrogate avoids this by modeling the objective globally and cheaply, letting the acquisition function be optimized by gradient ascent over the surrogate rather than over the black box.
+
+## Check your understanding
+
+1. Random search ignores everything it has already learned, yet it often beats grid search. Explain why the surrogate-plus-acquisition loop should beat random search specifically in the expensive-evaluation regime, and where that advantage disappears.
+2. The chunk-size tuning task has a budget of about 25 trials at 8 minutes each. Suppose someone proposes estimating a finite-difference gradient at the starting chunk size and following it. Reason through how much of the budget that consumes and what it buys you.
+3. The loop has four steps but only one of them touches the black box. Identify which step that is, and argue why moving work out of that step and into the other three is the entire point of the method.
+
+## What to remember
+
+**Bayesian optimization is for problems where each evaluation is expensive, the budget is tiny, and there is no usable gradient, so every query has to earn its cost.**
+
+- The loop is surrogate, then acquisition, then one black-box evaluation, then update, repeated until the budget runs out.
+- Only the black-box step is expensive; all the reasoning happens cheaply on the surrogate.
+- The regime is roughly 10 to 500 gradient-free evaluations that each take more than a few seconds; below it random search is fine, above it cheaper methods compete.
+
+Key insight: **sample efficiency, not scale, is the whole game; you are buying information per query, not throughput.**
 
 ## Notes
 

--- a/site/content/bayesian-optimization/ch02-gaussian-processes.mdx
+++ b/site/content/bayesian-optimization/ch02-gaussian-processes.mdx
@@ -4,20 +4,28 @@ export const meta = {
   title: 'Gaussian processes: a surrogate that quantifies its own doubt.',
   summary:
     'A GP places a prior over functions and updates it with observations to produce a posterior mean and variance at every untried point. The kernel encodes prior beliefs about smoothness; the marginal likelihood tunes it automatically.',
-  reading: '11 min',
+  reading: '14 min',
 };
 
 # Gaussian processes: a surrogate that quantifies its own doubt.
 
 <p className="chapter-lede">The key property of a GP surrogate is that it returns not just a predicted value but a confidence interval at every untried input. That uncertainty is what feeds the acquisition function. Without it, you have a point estimate and no principled way to trade off exploration and exploitation.</p>
 
+In Chapter 01 we described a loop that fits a surrogate and then queries it; this chapter answers the question that loop left open: what kind of model can stand in for an expensive objective and also say how much it does not yet know.
+
+A useful mental model: a Gaussian process is a belief map over the search space, continuously redrawn, shaded darker where the model is confident and lighter where it is unsure. The posterior mean is the map's best guess at the height of the terrain; the posterior variance is the thickness of the fog over each spot. The kernel, introduced below, is your assumption about how lumpy the terrain is, and how far a single clue carries.
+
+<p className="aside">A model that never reports doubt cannot be surprised, and a treasure hunter who is never surprised stops looking. The variance is the point.</p>
+
 ## What a GP is
 
-A Gaussian process is a probability distribution over functions. Any finite collection of function values drawn from a GP follows a joint Gaussian distribution, indexed by the input points. This is a strong statement: the model does not commit to a single function but maintains a distribution over all functions consistent with the prior and the data.
+A Gaussian process is a probability distribution over functions. Pick any finite set of input points, and the function values at those points follow one joint Gaussian distribution. That is the whole definition, and it is what makes the math tractable. This is a strong statement: the model does not commit to a single function but maintains a distribution over all functions consistent with the prior and the data.
 
 Two objects fully specify a GP prior: a mean function m(x), most often set to zero, and a kernel (covariance function) k(x, x'). The kernel encodes what the model believes about how function values co-vary across input space -- how smooth the function is expected to be, how quickly correlations decay with distance. <sup className="fn-ref"><a href="#fn-1">[1]</a></sup>
 
 The mean function sets the baseline prediction in regions with no observations. The kernel determines how information from one point propagates to nearby points. Both choices matter; the kernel matters more.
+
+For the `tell-me-why` chunk-size task, the GP is exactly this belief map: its input axis is the chunk size from 64 to 2048 tokens, and its output is the predicted recall@10. After a handful of trials the map is sharp near the chunk sizes you have already benchmarked and foggy everywhere between them. That fog is what tells the next chapter where it is still worth digging.
 
 ## Kernels: encoding prior beliefs about smoothness
 
@@ -63,6 +71,8 @@ The linear kernel is degenerate in the GP sense -- it does not produce stationar
 
 After observing n data points x_1 through x_n with corresponding outputs y, the GP posterior at a new test point x* has a closed-form mean and variance. These follow directly from the standard Gaussian conditioning identities. <sup className="fn-ref"><a href="#fn-1">[1]</a></sup>
 
+Before the equations, walk one number through by hand. Say you have benchmarked three chunk sizes and the GP is asked about a new one sitting close to a trial that scored recall@10 of 0.50. Because the new point is near a known clue, the kernel gives it a high cross-covariance, so the posterior mean is pulled close to 0.50 and the posterior variance is small: little fog, a confident guess. Now ask about a chunk size far from every trial. The cross-covariances are near zero, the mean falls back toward the prior (say 0.0 after centering), and the variance climbs back toward the full prior variance: thick fog, the model admits it is guessing. The two equations below are just the bookkeeping that produces those two numbers at every point.
+
 ```
 // pseudocode
 // GP conditioning equations
@@ -80,6 +90,8 @@ sigma_post^2(x*) = k_ss - k_s^T * K^{-1} * k_s
 ```
 
 Two properties follow immediately. The posterior variance collapses to the noise floor sigma_n^2 at observed points (or to zero in the noiseless case), because the GP interpolates (or near-interpolates) through the data. In regions far from all observations, the posterior variance approaches the prior variance k_ss -- the model returns to its prior when it has no relevant evidence.
+
+Read termwise: `k_s^T K^{-1} y` is the data pulling the mean toward nearby observed scores, and `k_ss - k_s^T K^{-1} k_s` is the prior fog minus however much the nearby data has burned off. When a test point is far from all data, `k_s` goes to zero, the mean returns to the prior, and the variance returns to `k_ss`.
 
 The acquisition function in Bayesian optimization reads both outputs: the posterior mean tells it where the objective is expected to be good, and the posterior variance tells it where there is still meaningful uncertainty. The balance between them determines the exploration-exploitation tradeoff.
 
@@ -272,6 +284,22 @@ The standard approach is Type-II maximum likelihood, also called empirical Bayes
 With few observations -- fewer than roughly 20 -- the marginal likelihood can be maximized to pathological values. The length scale collapses to zero, memorizing each data point exactly, or inflates to infinity, collapsing the posterior to the prior mean. Placing log-normal priors over the length scale and signal variance and then marginalizing over hyperparameters (via MCMC or HMC slice sampling) is more principled and more stable. <sup className="fn-ref"><a href="#fn-2">[2]</a></sup>
 
 The practical takeaway is that automatic hyperparameter tuning via marginal likelihood works well when the observation count is moderate (20 to 100 points). Below that threshold, prior specification over the hyperparameters matters as much as the choice of kernel.
+
+## Check your understanding
+
+1. At an observed point the posterior variance collapses to the noise floor, and far from all data it returns to the prior variance. Explain, in terms of the kernel matrix, why both behaviors fall out of the same conditioning equations.
+2. Two practitioners fit a GP to the same five chunk-size trials but choose different kernels, one RBF and one Matern 3/2. Predict where their posterior means will disagree most, and why the choice matters more in the gaps than at the data.
+3. With only eight observations, maximum marginal likelihood can drive the length scale to zero. Describe what the belief map looks like in that failure, and why it makes the next acquisition step useless.
+
+## What to remember
+
+**A Gaussian process is a surrogate that returns a predicted value and an honest confidence interval at every untried input, which is exactly what the acquisition function needs.**
+
+- The kernel encodes how smooth the objective is and how far one observation informs its neighbors; Matern 5/2 is the standard default.
+- The posterior mean says where the objective is likely good; the posterior variance, the thickness of the fog, says where the model is still unsure.
+- Marginal likelihood tunes the hyperparameters automatically, but with fewer than about 20 points it needs priors to stay sane.
+
+Key insight: **the value the GP returns is cheap; the uncertainty it returns alongside the value is what makes the whole loop work.**
 
 ## Notes
 

--- a/site/content/bayesian-optimization/ch03-acquisition-functions.mdx
+++ b/site/content/bayesian-optimization/ch03-acquisition-functions.mdx
@@ -4,16 +4,22 @@ export const meta = {
   title: 'Acquisition functions: turning uncertainty into the next query.',
   summary:
     'Expected improvement, probability of improvement, GP-UCB, and Thompson sampling each define a different policy for trading off exploration against exploitation. Optimizing the acquisition is cheap relative to the black-box objective.',
-  reading: '10 min',
+  reading: '13 min',
 };
 
 # Acquisition functions: turning uncertainty into the next query.
 
 <p className="chapter-lede">The acquisition function is the decision rule. It takes the GP posterior at every candidate point and outputs a scalar score. The next query goes to the candidate with the highest score. The entire explore-exploit balance is encoded in which acquisition function you choose and how you parameterize it.</p>
 
+In Chapter 02 we built a belief map that reports both a best guess and a fog thickness everywhere; this chapter answers the question that map left open: given the guess and the fog, where exactly should the next costly evaluation go.
+
+A useful mental model: the acquisition function is the scouting rule that decides where to dig next. It reads the belief map and scores every candidate by weighing two pulls against each other, looking where the map is still blank versus digging where treasure is most likely. Every acquisition function in this chapter is just a different scouting rule over the same map.
+
+<p className="aside">A scouting rule that only digs where treasure is most likely will happily mine the same hole forever. EI is what keeps the hunter glancing at the blank parts of the map.</p>
+
 ## Probability of improvement (PI)
 
-PI is the probability that evaluating point x produces a value above the current best y*. Under the GP posterior the value at x is Gaussian, so this probability is a CDF evaluation and is cheap to compute. The formula is compact and the computation is cheap.
+PI asks a simple question at each candidate: what is the chance that evaluating it beats the best score seen so far, y*. Under the GP posterior the value at that candidate is Gaussian, so the answer is one CDF lookup and costs almost nothing.
 
 The practical drawback is that PI tends to exploit. Near the current best, the mean is high and the probability of a small gain is large. Regions with high variance but a lower mean get lower PI scores even when their expected gain is substantial. Kushner introduced PI in 1964 as a sequential optimization procedure for noisy curve-fitting, predating the modern BO literature.<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>
 
@@ -21,11 +27,17 @@ Adding a small positive jitter xi to the improvement threshold -- scoring P(f(x)
 
 ## Expected improvement (EI)
 
-EI replaces the probability of any improvement with the expected magnitude of improvement. The score is E[max(f(x) - y*, 0)] under the GP posterior, which weights large gains more than small ones. Under a Gaussian posterior, the integral has a closed form: EI(x) = (mu(x) - y*) * Phi(Z) + sigma(x) * phi(Z), where Z = (mu(x) - y*) / sigma(x), and Phi and phi are the standard normal CDF and PDF.
+EI replaces the probability of any improvement with the expected magnitude of improvement. The score is E[max(f(x) - y*, 0)] under the GP posterior, which weights large gains more than small ones.
+
+Walk two candidate chunk sizes through it. The current best recall@10 is y* = 0.50. Candidate A has posterior mean 0.52 and tiny variance: it almost certainly beats y*, but only by about 0.02, so its expected improvement is small. Candidate B has mean 0.48, just under y*, but large variance: most draws miss, yet the occasional draw lands at 0.60, and because improvement only counts the upside and ignores the downside, those rare big wins make B's expected improvement larger than A's. EI prefers B. That asymmetry, upside counts and downside is floored at zero, is the entire idea, and the closed form below just integrates it.
+
+Under a Gaussian posterior, the integral has a closed form: EI(x) = (mu(x) - y*) * Phi(Z) + sigma(x) * phi(Z), where Z = (mu(x) - y*) / sigma(x), and Phi and phi are the standard normal CDF and PDF. Read the two terms: (mu(x) - y*) * Phi(Z) is the exploitation pull, large when the mean already clears y*, and sigma(x) * phi(Z) is the exploration pull, large when the fog is thick. Z just measures how many standard deviations the mean sits above y*.
 
 EI naturally balances exploration and exploitation without a tuning parameter. A point with a moderate mean and large variance can outscore a point with a high mean and near-zero variance if the integrated gain is larger. Jones, Schonlau, and Welch formalized this in the EGO algorithm for engineering design optimization, which remains the most-cited acquisition function paper.<sup className="fn-ref"><a href="#fn-2">[2]</a></sup>
 
 The closed form makes EI fast to evaluate and differentiate, so acquisition optimization by gradient ascent is straightforward. EI is the starting point for any new BO project.
+
+On the `tell-me-why` chunk-size task this is the step that turns the map into a decision. The GP has a best observed recall@10 so far, call it y*, and EI scans chunk sizes from 64 to 2048, scoring each by how much it expects to beat y*. The next 8-minute trial goes to the single chunk size with the highest score, not to the one with the highest predicted mean.
 
 ## GP-UCB
 
@@ -276,6 +288,22 @@ BoTorch is the practical standard for acquisition optimization in Python.<sup cl
     </tr>
   </tbody>
 </table>
+
+## Check your understanding
+
+1. PI and EI both compare candidates to y*, yet PI tends to exploit while EI stays balanced. Using the two-candidate walkthrough as a guide, explain what EI counts that PI throws away.
+2. GP-UCB is the only classical acquisition here with a regret bound, but most practitioners use a fixed beta rather than the schedule from the theorem. Reason about what the fixed-beta choice gains and what guarantee it gives up.
+3. The chunk-size budget allowed parallel reindexing of four corpora at once. Explain why Thompson sampling extends to that batch for free while EI needs a separate qEI formulation.
+
+## What to remember
+
+**The acquisition function turns the GP's mean and variance into a single score per candidate, and the next query goes to the highest score.**
+
+- PI exploits, EI balances exploration and exploitation with no tuning knob, GP-UCB exposes the balance through beta, and Thompson sampling gets it through randomness.
+- EI counts the expected size of an improvement and floors the downside at zero, which is why a foggy near-miss can outscore a confident small win.
+- The inner maximization over candidates is cheap relative to the black box, so it is solved with multi-start gradient ascent over a Sobol design.
+
+Key insight: **choosing where to dig next is a scoring problem, and the scoring happens entirely on the cheap surrogate, never on the expensive objective.**
 
 ## Notes
 

--- a/site/content/bayesian-optimization/ch04-the-loop-in-practice.mdx
+++ b/site/content/bayesian-optimization/ch04-the-loop-in-practice.mdx
@@ -4,20 +4,28 @@ export const meta = {
   title: 'The loop in practice: priors, noise, and where it breaks.',
   summary:
     'Kernel and length-scale priors matter more than most tutorials admit. Noisy observations, input warping, high-dimensional search spaces, and batch parallelism each require specific design choices that the basic loop glosses over.',
-  reading: '12 min',
+  reading: '15 min',
 };
 
 # The loop in practice: priors, noise, and where it breaks.
 
 <p className="chapter-lede">The derivation in Chapter 02 assumes noiseless observations and a well-specified kernel. Real problems have heteroskedastic noise, poorly-chosen length scales, discrete and conditional search spaces, and evaluation budgets that demand batch parallelism. Each of these issues has a known fix and a known failure mode.</p>
 
+In Chapter 03 we picked a scouting rule on the assumption that the belief map is trustworthy; this chapter answers the question that assumption left open: what happens when the map is built on the wrong length scale, noisy clues, or no clues at all.
+
+A useful mental model: the failures here are all bad assumptions about the terrain. A length scale that is too short means assuming a single clue carries no distance, so the fog snaps back to full thickness between digs; a length scale that is too long means assuming the island is one smooth hill, so real bumps get ironed flat. Tuning the loop is mostly tuning how lumpy you believe the terrain is.
+
+<p className="aside">A confident map drawn from three clues is more dangerous than an honest blank one. Most of this chapter is about keeping the map honest while the data is still thin.</p>
+
 ## Kernel and length-scale priors
 
-With fewer than roughly 20 observations, maximum likelihood estimation of the GP hyperparameters is unreliable. The length scale collapses toward zero -- memorizing every observed value, leaving no generalization between points -- or inflates toward infinity, reducing the posterior to the prior mean everywhere. Both failures look like reasonable GP fits on training data and produce useless acquisition functions.
+With only a handful of observations, say fewer than 20, fitting the GP hyperparameters by maximum likelihood is unreliable, and the two ways it fails are worth recognizing on sight. The length scale collapses toward zero -- memorizing every observed value, leaving no generalization between points -- or inflates toward infinity, reducing the posterior to the prior mean everywhere. Both failures look like reasonable GP fits on training data and produce useless acquisition functions.
 
 The standard remedy is to place priors on the length scale and signal variance before optimizing. A log-normal prior on the length scale encodes the belief that the function varies meaningfully over the scale of the search space, without ruling out fast or slow variation at the extremes. Snoek et al. 2012<sup className="fn-ref"><a href="#fn-1">[1]</a></sup> handle this by marginalizing over hyperparameters with slice sampling rather than committing to a single maximum-likelihood estimate. The marginal is more expensive but substantially more robust when data are scarce.
 
 The practical heuristic: set the prior mean of the log length scale to the log of the search-space diameter divided by four. That anchors the prior in the regime where the function is neither flat nor wildly oscillatory, and the data can pull it toward the truth as observations accumulate.
+
+The chunk-size task shows the stakes directly. The knob spans 64 to 2048 tokens, so the length-scale prior should expect recall@10 to change meaningfully over a few hundred tokens, not over a single token and not only across the whole range. The heuristic above, log length scale anchored at the log of the search-space diameter over four, lands the prior near a few hundred tokens, which is the right order of magnitude before any trial has run.
 
 <figure className="chapter-figure">
   <svg
@@ -136,6 +144,8 @@ The objective must have some structure for BO to exploit. Discontinuous objectiv
 
 BO overhead grows with the number of observations. GP fitting is cubic in the observation count. At 500 observations, fitting the GP on every iteration is slow; at 5000, it becomes a bottleneck. The practical threshold depends on hardware and implementation, but when it is reached, the standard remedies are sparse GP approximations or switching to a cheaper surrogate such as a random forest, which is the approach taken by SMAC.
 
+Cold start is visible in the chunk-size run too: the first five trials come from a Sobol design over 64 to 2048 tokens, not from the GP, because with zero observations the belief map is pure prior and has nothing to recommend. Those five digs buy the map its first shape, and only then does EI take over.
+
 <table className="encoding-table">
   <thead>
     <tr>
@@ -172,6 +182,22 @@ BO overhead grows with the number of observations. GP fitting is cubic in the ob
     </tr>
   </tbody>
 </table>
+
+## Check your understanding
+
+1. A short length scale and a long length scale both produce a GP that looks like a reasonable fit on the training points. Explain how each one nonetheless sabotages the acquisition step, using the fog image.
+2. Shot noise in an RB estimate goes onto the kernel diagonal as a tuned noise variance. Reason about what happens to the posterior, and to exploration, if that noise variance is fixed at zero instead.
+3. Cold start spends the first 5 to 20 evaluations on a space-filling design rather than on the acquisition function. Argue why this is a cost of starting without information rather than a flaw in the method.
+
+## What to remember
+
+**The clean loop assumes noiseless data and a well-specified kernel; real runs fight bad length scales, observation noise, high dimension, batching, and cold start, each with a known fix and a known failure mode.**
+
+- With scarce data, put priors on the length scale and noise variance so maximum likelihood cannot collapse the fit to memorization or to a flat prior.
+- High dimension hurts the acquisition optimization, not the GP fit; additive decomposition or random embedding is the usual escape.
+- Cold start is unavoidable: spend the first few digs on a space-filling design because the map has nothing to say yet.
+
+Key insight: **most BO failures are not bugs in the algorithm but wrong assumptions about how lumpy and how noisy the terrain is.**
 
 ## Notes
 

--- a/site/content/bayesian-optimization/ch05-bo-in-the-wild.mdx
+++ b/site/content/bayesian-optimization/ch05-bo-in-the-wild.mdx
@@ -4,16 +4,24 @@ export const meta = {
   title: 'Bayesian optimization in the wild: hyperparameters and qubit calibration.',
   summary:
     'Two worked domains: tuning ML embedding models (the RAG pipeline from the code-intelligence pillar) and qubit gate calibration (RB, T1, T2, gate tomography) framed as sequential black-box optimization. Reproducibility via seeds and fixtures.',
-  reading: '13 min',
+  reading: '16 min',
 };
 
 # Bayesian optimization in the wild: hyperparameters and qubit calibration.
 
-<p className="chapter-lede">Two domains, one algorithm. Hyperparameter tuning of an embedding model and single-qubit gate calibration both present as expensive black-box optimization with a small evaluation budget. The structure is identical; only the lab bench changes. This chapter also closes the cross-pillar loop: the embedding model is the one powering the code-intelligence RAG pipeline described in the code-intelligence book; the qubit calibration work connects to "Qubit calibration as an orchestration problem" in the writing pipeline.</p>
+<p className="chapter-lede">Two domains, one algorithm. Tuning an embedding pipeline and calibrating a single-qubit gate both show up as expensive black-box optimization on a small budget, which means both are the same treasure hunt with a different island. The structure is identical; only the lab bench changes. This chapter also closes the cross-pillar loop: the embedding model is the one powering the code-intelligence RAG pipeline described in the code-intelligence book; the qubit calibration work connects to "Qubit calibration as an orchestration problem" in the writing pipeline.</p>
+
+In Chapter 04 we hardened the loop against bad priors, noise, and cold start on a single knob; this chapter answers the question that hardening left open: does the same structure survive a real mixed search space, and does it transfer to a second domain that looks nothing like the first.
+
+A useful mental model: it is the same treasure hunter on a foggy island, only now the island has more than one dimension and the second island is a quantum chip. The belief map, the fog, the kernel assumption, and the scouting rule do not change when the terrain becomes hyperparameters or drive pulses. Two domains, one map.
+
+<p className="aside">The qubit chip and the retrieval benchmark have never met. The treasure hunter does not notice the difference.</p>
 
 ## Domain 1: tuning ML embedding models
 
 The code-intelligence book's retrieval pipeline -- built around `tell-me-why` -- uses an embedding model to represent code chunks and queries in a shared vector space. Three parameters govern retrieval quality: the choice of embedding model, the chunk size at indexing time, and the top-k value used at query time. Evaluating any single configuration requires running the full retrieval benchmark against a fixed held-out query set. That benchmark takes minutes per trial on a GPU, and the search space mixes discrete choices (model name) with continuous ones (chunk size, top-k threshold). This is the mixed continuous-discrete regime where BO earns its keep.<sup className="fn-ref"><a href="#fn-1">[1]</a></sup>
+
+The chunk-size knob from the earlier chapters was a deliberate one-dimensional slice of exactly this problem. Here it rejoins its two companions: the chunk size from 64 to 2048 tokens becomes one continuous axis alongside the discrete embedding-model choice and the continuous top-k threshold. The objective is unchanged, recall@10 on the fixed held-out query set, and the budget per trial is the same roughly 8 minutes of GPU time. BO does not care that one axis is now discrete; it just optimizes the acquisition over a mixed space.
 
 The loop runs as follows. Five initial configurations are drawn from a Sobol low-discrepancy sequence, covering the search space without clustering. A Matern 5/2 GP is fitted to those five observations, then EI selects the sixth configuration, the benchmark runs, and the result is appended to the dataset. Repeat until the budget is exhausted. The objective is recall@10 on the held-out query set: the fraction of ground-truth relevant chunks that appear in the top-10 retrieved results.
 
@@ -22,6 +30,8 @@ The implementation uses BoTorch for the acquisition optimization step.<sup class
 ## Domain 2: qubit gate calibration as BO
 
 Single-qubit gate calibration requires sweeping drive parameters -- primarily drive amplitude and drive frequency -- to maximize gate fidelity. Each candidate parameter setting is evaluated by running a randomized benchmarking (RB) circuit sequence on the QPU and fitting the decay curve to extract an error-per-gate estimate. One RB sequence takes minutes of device time. The total calibration budget is typically 20 to 100 trials per qubit, depending on how tight the fidelity target is and how stable the device is.
+
+Read the qubit task against the chunk-size task and the structure lines up point for point: drive amplitude and frequency replace chunk size and top-k, gate fidelity from randomized benchmarking replaces recall@10, and minutes of QPU time replace minutes of GPU time. The map, the kernel, and the acquisition rule are identical; only the lab bench changed.
 
 This connects to "Qubit calibration as an orchestration problem" in the writing pipeline, which frames the same workflow as resource allocation across multiple qubits and calibration types (T1, T2, RB, gate tomography). The BO perspective and the orchestration perspective are complementary: BO decides which parameter setting to try next within a single calibration task; the orchestration layer decides which calibration tasks to run and in what order.
 
@@ -184,6 +194,22 @@ For the qubit calibration domain, the fixture also records the RB circuit parame
 The three pillars -- ML, quantum, code-intelligence -- share the problem structure of expensive black-box evaluation with a limited budget. BO is one instance of a broader principle: the structured artifact carries more information than its surface form. The GP posterior is that structured artifact; it encodes not just the best observed value but the full landscape of uncertainty over the search space. The raw evaluation budget is the surface form, and querying it without a surrogate discards the information you already have.
 
 The code-intelligence connection is direct: the embedding model whose hyperparameters are being tuned by BO is the same model powering the retrieval layer described in the code-intelligence book. The quantum connection runs through the orchestration layer: BO decides which parameter to try next within a calibration task, while the orchestration problem -- described in "Qubit calibration as an orchestration problem" -- decides which tasks to schedule across a multi-qubit device. Both decisions are instances of information-theoretic resource allocation under constraint, and the GP posterior is what makes the within-task decision principled.
+
+## Check your understanding
+
+1. The comparison table lists the chunk-size domain as low-noise and the qubit domain as moderate-noise. Reason about how that single difference should change the kernel diagonal and the choice between EI and GP-UCB.
+2. Replaying a saved BO fixture reproduces the chunk-size run exactly but not the qubit run's fidelity values. Explain which part of the run is reproducible regardless of hardware, and why that is the part that matters for verification.
+3. The chapter claims the GP posterior carries more information than the raw evaluation budget. Argue what specifically is lost if you keep only the best observed value and discard the posterior.
+
+## What to remember
+
+**Hyperparameter tuning and qubit gate calibration are the same Bayesian optimization problem wearing different hardware, and the GP posterior is the artifact that makes both reproducible.**
+
+- The mixed continuous-discrete chunk-size, model, top-k space and the continuous amplitude-frequency space are both just search spaces the acquisition optimizes over.
+- Device drift breaks exact reproduction of fidelity values, but the optimization logic stays verifiable from a seeded fixture.
+- Fix all three sources of randomness, the Sobol design, the acquisition restarts, and the GP hyperparameter initialization, or two runs diverge.
+
+Key insight: **once you see the loop as a treasure hunt over a belief map, the domain stops mattering; the structure is what transfers.**
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Enhanced the Bayesian optimization book with pedagogical scaffolding to improve retention and comprehension. Added a sustained mental-model metaphor (treasure hunter on a foggy island), threaded a concrete running example (chunk-size tuning for the `tell-me-why` RAG pipeline) through all five chapters, and structured each chapter with explicit learning checkpoints.

## Key Changes

- **Mental models and metaphors**: Introduced a consistent "treasure hunter on a foggy island" metaphor in Chapter 01 and adapted it across all chapters (belief map, fog thickness, scouting rules, etc.)

- **Running example**: Wove the `tell-me-why` chunk-size tuning task (64–2048 tokens, ~8 min per trial, ~25 trial budget) through all five chapters as a concrete instantiation of abstract concepts

- **Chapter bridges**: Added one-sentence transitions in Chapters 02–05 that explicitly connect each chapter to the previous one ("In Chapter NN we ...; this chapter answers the question that left open: ...")

- **Intuition before equations**: Added numeric walkthroughs before key equations:
  - GP posterior conditioning: hand-worked example of how cross-covariance pulls the mean and collapses variance
  - Expected Improvement: two-candidate comparison showing why EI prefers a foggy near-miss over a confident small win
  - Posterior variance behavior: termwise explanation of the conditioning formula

- **Retention blocks**: Added two new sections before `## Notes` in each chapter:
  - `## Check your understanding`: 3 reasoning questions that build on the chapter content
  - `## What to remember`: bold summary statement, 3-bullet list of key takeaways, bold `Key insight:` line

- **Memory hooks**: Added exactly one `<p className="aside">` per chapter with memorable, quotable insights (e.g., "A model that never reports doubt cannot be surprised, and a treasure hunter who is never surprised stops looking.")

- **Reading time updates**: Adjusted estimated reading times to reflect added content (9→12, 11→14, 10→13, 12→15, 13→16 minutes)

- **Documentation**: Updated `AGENTS.md` with the retention scaffolding pattern as a reference implementation for future books

## Implementation Details

- All changes use existing Markdown and CSS primitives (`.aside` class only)
- No new components or SVG elements added
- Running example is grounded in real infrastructure (the code-intelligence pillar's RAG pipeline)
- Metaphor is consistent across chapters but adapted to each domain (hyperparameters, qubit calibration)
- Retention blocks are placed immediately before `## Notes` to preserve section ordering

https://claude.ai/code/session_01HCzCZnscGdYYP6akmDFg9q