### PR TITLE
Add slides system with photonic integrated circuits deck series

### DIFF
--- a/.agent/slides-system.md
+++ b/.agent/slides-system.md
@@ -1,0 +1,200 @@
+# Slides System
+
+This document governs the `Slides` section of the site (`/slides/`). It is
+the binding reference for how a deck is built, where it lives, and what it
+is allowed to look like. Decks are reveal.js pages. The visual tokens are
+the same ones the rest of the site uses (`.agent/visual-system.md`); this
+document only adds what is specific to a full-screen, stepwise deck.
+
+Reference implementation:
+`site/public/slides/photonic-integrated-circuits/01-introduction/index.html`.
+
+---
+
+## Purpose
+
+A deck exists to make an explanation easier than prose would. It leans on
+animated SVG diagrams, stepwise reveals, and tables. If a slide could be a
+paragraph, it should be a paragraph in the blog instead. The blog is for
+reading; the slides are for showing.
+
+---
+
+## Structure
+
+The Slides tab mirrors the Blog tab: an index page, "folders" (a series of
+decks on one topic), and standalone decks.
+
+| Piece | Location | Notes |
+|-------|----------|-------|
+| Nav item | `site/components/Nav.tsx` | `{ href: '/slides/', label: 'slides' }`, beside `blog` |
+| Registry | `site/app/slides/decks.ts` | `SLIDES: SlideEntry[]`, one `DeckFolder` or `StandaloneDeck` per entry; each folder exports its own `Deck[]` constant |
+| Index page | `site/app/slides/page.tsx` | Reuses the `.blog-list` / `.blog-entry` classes; folders list their decks inline the way books list chapters |
+| Folder page | `site/app/slides/<folder-slug>/page.tsx` | Reuses `.book-eyebrow` + `.chapter-toc`; sets `data-pillar` on `<main>` |
+| Deck | `site/public/slides/<folder-slug>/<deck-slug>/index.html` | One self-contained reveal.js HTML file; static, copied verbatim into the export |
+| URL helper | `site/lib/site-config.ts` | `deckUrl(folder, deck)` prefixes `SITE_BASE_PATH` for plain `<a href>` links |
+
+Deck slugs are zero-padded and ordered: `01-introduction`, `02-...`. Folder
+slugs are kebab-case topic names: `photonic-integrated-circuits`.
+
+Decks live under `public/`, not under `app/`, on purpose:
+
+- `globals.css` constrains `<main>` to a reading column and restyles every
+  heading and paragraph; a full-screen deck should not fight it.
+- A deck is a single file that can be opened, copied, or presented offline
+  with nothing but a browser.
+- Next.js does not process `public/`, so Link-prefetch and client routing
+  never touch a deck. Link to a deck with a plain `<a href={deckUrl(...)}>`,
+  never `<Link>`.
+
+Links from inside a deck back to the site are relative (`../../../slides/`,
+`../../../`), so the deck works under the Pages `basePath` and from a local
+static server alike.
+
+---
+
+## Adding a deck
+
+1. Author `site/public/slides/<folder>/<NN-slug>/index.html`. Start from the
+   reference deck: copy its `<head>`, `<style>`, the `.deck-label`, and the
+   `<script>` block, then replace the `<section>`s.
+2. Register it in `site/app/slides/decks.ts`: add a `Deck` to the folder's
+   array (number, slug, title, summary, `length` as `'NN slides'`, and a
+   `source` when adapted from a lecture or paper).
+3. If it is a new folder: add a `DeckFolder` to `SLIDES`, create
+   `site/app/slides/<folder>/page.tsx` from the photonic-integrated-circuits
+   page, and confirm `main[data-pillar="<pillar>"]` exists in `globals.css`.
+4. If it is a standalone deck: add a `StandaloneDeck` to `SLIDES`, pointing
+   `folder` at the `public/slides/<folder>/` directory that holds it.
+5. `cd site && npm run typecheck && npm run lint && npm run build`, then open
+   `out/slides/<folder>/<deck>/index.html` through a static server and step
+   through every slide once with the keyboard.
+
+---
+
+## Deck anatomy
+
+Every deck has, in order:
+
+1. **Title slide.** Eyebrow (`pillar | series | deck NN`), H1, one-line
+   summary, an animated hero SVG, and the key hint
+   (`Arrow keys to move. f fullscreen. ? key map.`).
+2. **Content slides.** Each carries an eyebrow with a bracket number
+   `[ NN ]` and the section name, one H2 that states the claim of the slide
+   (a sentence, not a topic label), and one figure or table.
+3. **Check your understanding.** Three reasoning questions as fragments,
+   then a `what to remember` card. Same retention scaffolding as a blog
+   chapter.
+4. **End slide.** What the next deck covers, the source attribution with a
+   link, and links back to the folder page and the slides index.
+
+Numbering: content slides are numbered `[ 01 ]` upward in the eyebrow.
+Auto-animate pairs share one number. The title and end slides carry the
+series eyebrow instead of a number.
+
+---
+
+## Content rules
+
+- **One claim per slide.** The H2 is the claim. If a slide needs two H2s
+  it is two slides.
+- **Figure or table on every content slide.** A slide with only text is
+  not allowed outside the check-your-understanding and end slides.
+- **Fragments carry the argument.** Reveal a diagram in the order the
+  explanation needs it; use `data-fragment-index` explicitly so the text
+  and the drawing step together.
+- **Tables use the site recipe.** Mono uppercase headers on the rail
+  surface, the first column in the accent, hairline row borders. Rows may
+  be fragments.
+- **Interactivity is welcome when it teaches.** A slider that changes a
+  physical quantity (the Mach-Zehnder phase demo) is the model. Guard
+  reveal's keyboard handling with `keyboardCondition` so form controls own
+  their own arrow keys.
+- **Attribution.** A deck adapted from a lecture or paper names it on the
+  end slide with a link and states which parts are original (diagrams,
+  demos, ordering).
+- **Voice.** Same as `.agent/writing-strategy.md`: direct, second person
+  allowed, no hype, no emoji anywhere in the file (hard rule from
+  `AGENTS.md`).
+
+---
+
+## Visual rules
+
+Tokens are copied into the deck's `:root` from `globals.css`; keep them in
+sync when the site palette changes.
+
+- **Surfaces and text.** `--bg`, `--card`, `--rail`, `--elevated`,
+  `--hair`, `--strong`, `--text`, `--muted`, `--footnote` map one to one
+  onto the site tokens. Dark only; decks do not carry the light toggle.
+- **Accent.** The deck's `--accent` is the pillar colour of its folder
+  (photonics is amber `#fbbf24`). The other pillar hues are available for
+  semantic contrast only: cyan for electrical signals, violet for a second
+  path or an acoustic wave, emerald for detectors and single photons.
+  Do not use them decoratively.
+- **Type.** Fraunces for headings, Inter for prose, JetBrains Mono for
+  eyebrows, labels, table headers, and SVG text. Weights 400, 500, 600 only.
+- **Chrome.** 1px accent hairline across the top of the viewport (the
+  site's top-of-page motif), a 2px accent progress bar, mono `c/t` slide
+  number bottom-right, and a fixed mono deck label bottom-left linking to
+  `~/sk` and `slides`.
+- **Layout.** `center: false`, left-ragged text, `1180 x 700` logical
+  canvas, two-column `.cols` grid (text left, figure right) as the default
+  content layout. Prose measures at most `34em`.
+
+---
+
+## SVG rules
+
+Same rules as the site's diagrams (`AGENTS.md` § Diagrams workflow), with
+the additions a deck needs:
+
+- Inline `<svg>` only. Never `<img src>`.
+- Geometric primitives only (rect, path, line, circle, text). No glyph
+  icons.
+- Every figure carries `role="img"`, a `<title>`, and a `<desc>` that
+  describes the mechanism technically. Catalogue thumbnails are
+  `aria-hidden="true"`.
+- Strokes at `1.5px` or wider. Light beams use the accent at `2.5px`.
+- Use the shared classes: `.box` (node), `.box.acc` (accent node),
+  `.chip` (substrate), `.guide` (waveguide body), `.beam` (light),
+  `.elec` (electrical signal), `.dot` (photon), `.wire` (neutral line).
+- Reuse the same figure grammar across decks so a reader learns it once:
+  amber lines are light, cyan square pulses are electronics, a green dot
+  in a box is a detector, a translucent amber band is a waveguide.
+
+---
+
+## Animation rules
+
+Motion is opacity, stroke, or position along a path. Nothing bounces,
+scales, or spins.
+
+| Class | Effect | Trigger |
+|-------|--------|---------|
+| `.draw` | Stroke draws itself in (`stroke-dashoffset` to 0); set `--len`, `--dur`, `--delay` inline | `section.present` or `.fragment.visible` |
+| `.flowing` | Moving dash pattern along a beam | same |
+| `.rider` | A dot travels the beam via `offset-path`; set `--dur`, `--delay` | same |
+| `.blink` | Detector pip pulses | same |
+| `.appear` | Fade up by 8px; set `--delay` | same |
+
+- Animations key off reveal's `.present` and `.fragment.visible` classes
+  so they replay every time a slide or fragment is entered.
+- Animations inside an unrevealed fragment are held (`animation: none`)
+  until the fragment becomes visible.
+- Slide transition is `fade`; auto-animate is allowed for a before/after
+  pair that shares `data-auto-animate-id` and `data-id` attributes.
+- `prefers-reduced-motion: reduce` resolves every animation to its final
+  state and sets the reveal transition to `none`. This is mandatory, not
+  optional.
+- No autoplay and no timed slide advance. The reader drives.
+
+---
+
+## Dependencies
+
+- reveal.js is loaded from jsDelivr, pinned to an exact version
+  (`reveal.js@6.0.1`, `dist/reveal.css` and `dist/reveal.js`). Bump the
+  pin deliberately and re-test every deck.
+- Fonts come from Google Fonts with real fallback stacks.
+- No plugins, no markdown, no build step. The HTML is the source.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ conventions.
 - Repo conventions (naming, README skeleton, commit hygiene, releases): `.agent/repo-conventions.md`
 - Writing strategy (topics, pipeline, voice, citation policy): `.agent/writing-strategy.md`
 - Visual system (design tokens, typography, color, spacing, hero diagram): `.agent/visual-system.md`
+- Slides system (deck structure, reveal.js rules, SVG and animation grammar): `.agent/slides-system.md`
 - Site source: `site/` (Next.js, own `package.json`; run all npm commands from there)
 - Site deploy: GitHub Actions workflow at `.github/workflows/site.yml` builds `site/` and uploads to Pages via `actions/deploy-pages`. Build output (`site/out/` or local `docs/`) is gitignored. Do not commit it.
 - Design specs: `superpowers/specs/`
@@ -51,8 +52,8 @@ binding visual primitives. The binding visual rules live in
 - `PillarDiagram.tsx`. The canonical ASCII hero. Its string constant is
   locked verbatim; never edit it.
 - `Hero.tsx`. Wraps `<PillarDiagram>`, the tagline reveal (split into pillar-colored spans: `parsers` (sky/code-int) + muted arrow + `qubits.` (emerald/quantum); text content stays exactly `parsers -> qubits.` per the lock), `<StatsLine>`, and `<Nav>`.
-- `Nav.tsx`. Primary nav with active-state in `var(--color-accent)`; embeds
-  `<ThemeToggle>`.
+- `Nav.tsx`. Primary nav (`home`, `blog`, `slides`) with active-state in
+  `var(--color-accent)`; embeds `<ThemeToggle>`.
 - `ThemeToggle.tsx`. Client component; flips `[data-theme]` and persists to
   `localStorage`. ASCII label `[ light ]` / `[ dark ]`, no icons.
 - `StatusDot.tsx`. Small accent pip + monospace label; pulse animation is
@@ -74,6 +75,7 @@ binding visual primitives. The binding visual rules live in
   Source intent is documented in `site/diagrams/*.mmd` (mermaid flowcharts).
 - `StatsLine.tsx`. Server component. Renders the monospace pillars/repos/stack/last-build line under the hero tagline on Home. Reads `BUILD_META` from `site/lib/build-meta.ts`. Never imported from a client component.
 - `lib/build-meta.ts`. Build-time constants for `StatsLine`. `lastBuild` resolves at static-export time.
+- `lib/site-config.ts`. `SITE_BASE_PATH` (mirrors `basePath` in `next.config.mjs`) and `deckUrl()`, the only sanctioned way to link to a static deck under `public/`.
 - `scripts/verify-contrast.mjs`. WCAG contrast gate; runs as a pre-step of `npm run build` via `npm run verify-contrast`. Source of pair list: `.agent/visual-system.md` § Surface contrast verification.
 - `FootnoteList.tsx`, `FooterSignature.tsx`, `SkipLink.tsx`. Supporting components.
 
@@ -189,6 +191,67 @@ To add one, create the following files and registrations:
   - End each chapter with two retention blocks in this order, placed BEFORE the final `## Notes` section: `## Check your understanding` (3 reasoning questions) and `## What to remember` (bold one-sentence summary, 3-bullet list, bold `Key insight:` line). `## Notes` must remain the last section.
   - Include exactly one `<p className="aside">` memory hook per chapter.
   - Use plain Markdown plus the existing `.aside` primitive only. No new CSS, no new components, no new SVG.
+
+## Adding a slide deck to the slides section
+
+The `Slides` tab (`/slides/`) sits beside `Blog` in the nav and mirrors its
+shape: an index page, "folders" (a series of decks on one topic), and
+standalone decks. Decks are reveal.js pages built for explanation: animated
+inline SVG, stepwise fragments, tables, and the occasional interactive demo.
+The binding rules live in `.agent/slides-system.md`; read it before touching
+anything under `site/app/slides/` or `site/public/slides/`.
+
+**File layout:**
+
+- `site/app/slides/decks.ts` -- registry. `SLIDES: SlideEntry[]` holds one
+  `DeckFolder` (slug, title, summary, pillar, date, status, `decks`) or
+  `StandaloneDeck` per entry. Each folder's `Deck[]` (number, slug, title,
+  summary, `length` as `'NN slides'`, optional `source`) is its own export.
+- `site/app/slides/page.tsx` -- index page; renders `SLIDES` with the
+  `.blog-list` classes, decks listed inline under their folder.
+- `site/app/slides/<folder-slug>/page.tsx` -- folder page; `.chapter-toc`
+  list of decks, `data-pillar` on `<main>`.
+- `site/public/slides/<folder-slug>/<NN-slug>/index.html` -- the deck. One
+  self-contained reveal.js file (reveal pinned from jsDelivr, tokens copied
+  from `globals.css`, no build step). Reference:
+  `photonic-integrated-circuits/01-introduction/index.html`.
+
+**Registration:**
+
+- New deck in an existing folder: append a `Deck` to that folder's array.
+- New folder: add a `DeckFolder` to `SLIDES`, create the folder page from the
+  photonic-integrated-circuits one, and confirm a
+  `main[data-pillar="<pillar>"]` rule exists in `globals.css`.
+- Standalone deck: add a `StandaloneDeck` whose `folder` names the
+  `public/slides/<folder>/` directory that holds it.
+
+**Linking gotcha:**
+
+- Decks are static files under `public/`, so they are outside the Next.js
+  router. Link to them with a plain `<a href={deckUrl(folder, deck)}>` from
+  `site/lib/site-config.ts`, never `<Link>`. `deckUrl` prefixes the Pages
+  `basePath`. Links inside a deck back to the site are relative
+  (`../../../slides/`).
+
+**Deck rules (summary; full text in `.agent/slides-system.md`):**
+
+- Order: title slide, content slides, `Check your understanding` (three
+  questions plus a `what to remember` card), end slide with next-deck
+  pointer, attribution link, and links back to the folder and index.
+- One claim per slide; the H2 is the claim. Every content slide has a figure
+  or a table. Fragments step the drawing and the text together.
+- Tokens, fonts, and chrome match the site: dark surfaces, the folder's
+  pillar colour as `--accent`, Fraunces / Inter / JetBrains Mono, top
+  hairline, mono slide number, fixed deck label.
+- SVG: inline only, primitives only, `role="img"` + `<title>` + `<desc>`,
+  strokes at 1.5px or wider, shared figure grammar (`.beam`, `.elec`,
+  `.dot`, `.guide`, `.box`, `.chip`).
+- Motion is opacity, stroke, or travel along a path, keyed to reveal's
+  `.present` / `.fragment.visible` classes. `prefers-reduced-motion`
+  resolves everything to its final state. No autoplay.
+- No emoji, no plugins, no markdown, no `<img>`.
+
+**Existing folders:** `photonic-integrated-circuits` (1 deck).
 
 ## Adding a new repo to the profile
 

--- a/site/app/slides/decks.ts
+++ b/site/app/slides/decks.ts
@@ -1,0 +1,77 @@
+/**
+ * Registry of slide decks. Mirrors the book/chapter registry under
+ * app/writing/<slug>/chapters.ts.
+ *
+ * A "folder" groups several decks on one topic under /slides/<slug>/.
+ * A folder's decks are static reveal.js pages under
+ * public/slides/<folder-slug>/<deck-slug>/index.html.
+ * A "standalone" entry is a single deck with no folder page.
+ */
+
+export type Pillar = 'code-int' | 'ml' | 'quantum' | 'photonics';
+
+export type Deck = {
+  number: string;
+  slug: string;
+  title: string;
+  summary: string;
+  /** Slide count, e.g. '14 slides'. */
+  length: string;
+  /** Lecture / paper the deck is adapted from, shown on the folder page. */
+  source?: { label: string; href: string };
+};
+
+export type DeckFolder = {
+  kind: 'folder';
+  slug: string;
+  title: string;
+  summary: string;
+  pillar: Pillar;
+  pillarLabel: string;
+  date: string;
+  status: 'upcoming' | 'draft' | 'published';
+  decks: Deck[];
+};
+
+export type StandaloneDeck = {
+  kind: 'standalone';
+  /** Folder slug under public/slides/ that holds the deck. */
+  folder: string;
+  deck: Deck;
+  pillar: Pillar;
+  pillarLabel: string;
+  date: string;
+  status: 'upcoming' | 'draft' | 'published';
+};
+
+export type SlideEntry = DeckFolder | StandaloneDeck;
+
+export const PHOTONIC_IC_DECKS: Deck[] = [
+  {
+    number: '01',
+    slug: '01-introduction',
+    title: 'Photonic integrated circuits: an introduction',
+    summary:
+      'What integrated photonics is, the three inventions that turned optics into photonics, the sub-fields photonics absorbed, and why a guided-wave circuit on a planar substrate is the whole idea.',
+    length: '21 slides',
+    source: {
+      label: 'NPTEL, Lec 05 Photonic integrated circuits: an introduction',
+      href: 'https://www.youtube.com/watch?v=MOKPFINLPXE',
+    },
+  },
+];
+
+export const SLIDES: SlideEntry[] = [
+  {
+    kind: 'folder',
+    slug: 'photonic-integrated-circuits',
+    title: 'Photonic integrated circuits',
+    summary:
+      'A lecture-by-lecture deck series on photonic integrated circuits: what gets integrated, why light needs a waveguide once it leaves the optical table, and how the component physics builds up to a circuit.',
+    pillar: 'photonics',
+    pillarLabel: 'photonics',
+    date: '2026-Q3',
+    status: 'draft',
+    decks: PHOTONIC_IC_DECKS,
+  },
+];

--- a/site/app/slides/page.tsx
+++ b/site/app/slides/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Hero from '@/components/Hero';
+import FooterSignature from '@/components/FooterSignature';
+import { deckUrl } from '@/lib/site-config';
+import { SLIDES } from './decks';
+
+export const metadata: Metadata = {
+  title: 'Slides | Shubham Kaushal',
+  description:
+    'Interactive reveal.js slide decks with SVG animations, diagrams, and tables across photonics, quantum computing, machine learning, and code intelligence.',
+};
+
+export default function SlidesPage() {
+  return (
+    <main id="main">
+      <Hero variant="compact" />
+      <h1>Slides</h1>
+      <p>
+        Interactive decks built with reveal.js. Each one leans on animated SVG
+        diagrams, stepwise reveals, and tables rather than bullet walls, so a
+        topic can be explained on screen the way it would be at a whiteboard.
+        Folders group the decks of one series; standalone decks stand on their
+        own. Arrow keys move between slides; press <span className="kbd">?</span> inside
+        a deck for the full key map.
+      </p>
+      <ol className="blog-list">
+        {SLIDES.map((entry) => {
+          if (entry.kind === 'folder') {
+            return (
+              <li key={entry.slug} className="blog-entry" data-pillar={entry.pillar}>
+                <div className="blog-entry__meta">
+                  <time className="blog-entry__date">{entry.date}</time>
+                  <span className="blog-entry__pillar">{entry.pillarLabel}</span>
+                  <span className="blog-entry__status">{entry.status}</span>
+                  <span className="blog-entry__status">folder</span>
+                </div>
+                <h3 className="blog-entry__title">
+                  <Link href={`/slides/${entry.slug}/`} className="blog-entry__title-link">
+                    {entry.title}
+                  </Link>
+                </h3>
+                <p className="blog-entry__summary">{entry.summary}</p>
+                <ol className="blog-entry__chapters">
+                  {entry.decks.map((deck, j) => (
+                    <li key={deck.slug} className="blog-entry__chapter">
+                      <span className="blog-entry__chapter-num">{`[ ${String(j + 1).padStart(2, '0')} ]`}</span>
+                      <a
+                        href={deckUrl(entry.slug, deck.slug)}
+                        className="blog-entry__chapter-title blog-entry__chapter-link"
+                      >
+                        {deck.title}
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              </li>
+            );
+          }
+          return (
+            <li key={entry.deck.slug} className="blog-entry" data-pillar={entry.pillar}>
+              <div className="blog-entry__meta">
+                <time className="blog-entry__date">{entry.date}</time>
+                <span className="blog-entry__pillar">{entry.pillarLabel}</span>
+                <span className="blog-entry__status">{entry.status}</span>
+                <span className="blog-entry__status">deck</span>
+              </div>
+              <h3 className="blog-entry__title">
+                <a href={deckUrl(entry.folder, entry.deck.slug)} className="blog-entry__title-link">
+                  {entry.deck.title}
+                </a>
+              </h3>
+              <p className="blog-entry__summary">{entry.deck.summary}</p>
+            </li>
+          );
+        })}
+      </ol>
+      <FooterSignature />
+    </main>
+  );
+}

--- a/site/app/slides/photonic-integrated-circuits/page.tsx
+++ b/site/app/slides/photonic-integrated-circuits/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+import Hero from '@/components/Hero';
+import FooterSignature from '@/components/FooterSignature';
+import { deckUrl } from '@/lib/site-config';
+import { PHOTONIC_IC_DECKS } from '../decks';
+
+const FOLDER = 'photonic-integrated-circuits';
+
+export const metadata: Metadata = {
+  title: 'Photonic integrated circuits | Slides | Shubham Kaushal',
+  description:
+    'A lecture-by-lecture deck series on photonic integrated circuits: what gets integrated, why light needs a waveguide once it leaves the optical table, and how the component physics builds up to a circuit.',
+};
+
+export default function PhotonicIcSlidesPage() {
+  return (
+    <main id="main" data-pillar="photonics">
+      <Hero variant="compact" />
+      <p className="book-eyebrow">photonics · slides</p>
+      <h1>Photonic integrated circuits</h1>
+      <p>
+        A deck series that follows the NPTEL lecture sequence on photonic
+        integrated circuits. The first deck is the introduction: what
+        integrated photonics means, the three inventions that turned optics
+        into photonics, the sub-fields photonics absorbed on the way, and the
+        one design move (guided waves on a planar substrate) that makes it a
+        circuit. Later decks pick up the component physics.
+      </p>
+      <ol className="chapter-toc">
+        {PHOTONIC_IC_DECKS.map((d) => (
+          <li key={d.slug} className="chapter-toc__item">
+            <a href={deckUrl(FOLDER, d.slug)} className="chapter-toc__link">
+              <span className="chapter-toc__num">{`[ ${d.number} ]`}</span>
+              <span className="chapter-toc__body">
+                <span className="chapter-toc__title">{d.title}</span>
+                <span className="chapter-toc__summary">{d.summary}</span>
+                <span className="chapter-toc__reading">
+                  {d.length}
+                  {d.source ? ` · adapted from ${d.source.label}` : ''}
+                </span>
+              </span>
+            </a>
+          </li>
+        ))}
+      </ol>
+      <FooterSignature />
+    </main>
+  );
+}

--- a/site/components/Nav.tsx
+++ b/site/components/Nav.tsx
@@ -7,6 +7,7 @@ import ThemeToggle from './ThemeToggle';
 const ITEMS = [
   { href: '/', label: 'home' },
   { href: '/writing/', label: 'blog' },
+  { href: '/slides/', label: 'slides' },
 ];
 
 export default function Nav() {

--- a/site/lib/site-config.ts
+++ b/site/lib/site-config.ts
@@ -1,0 +1,13 @@
+/**
+ * Site-wide constants shared by server components.
+ *
+ * SITE_BASE_PATH mirrors `basePath` in next.config.mjs. Next.js prefixes it
+ * automatically on <Link> and asset URLs, but plain <a href> links to files
+ * under `public/` (the reveal.js decks) must prefix it by hand.
+ */
+export const SITE_BASE_PATH = '/shubhamkaushal765';
+
+/** Public URL of a static deck: `/slides/<folder>/<deck>/` under public/. */
+export function deckUrl(folder: string, deck: string): string {
+  return `${SITE_BASE_PATH}/slides/${folder}/${deck}/`;
+}

--- a/site/public/slides/photonic-integrated-circuits/01-introduction/index.html
+++ b/site/public/slides/photonic-integrated-circuits/01-introduction/index.html
@@ -1,0 +1,1104 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Photonic integrated circuits: an introduction | Slides | Shubham Kaushal</title>
+<meta name="description" content="What integrated photonics is, the three inventions that turned optics into photonics, the sub-fields photonics absorbed, and why a guided-wave circuit on a planar substrate is the whole idea.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@6.0.1/dist/reveal.css">
+<style>
+/* ── Tokens: mirrors site/styles/globals.css and .agent/visual-system.md ── */
+:root {
+  --bg: #0a0a0f;
+  --card: #131320;
+  --rail: #1b1b28;
+  --elevated: #181826;
+  --hair: rgba(255, 255, 255, 0.07);
+  --strong: rgba(255, 255, 255, 0.12);
+  --text: #f0ede5;
+  --muted: #a3a098;
+  --footnote: #757269;
+  --accent: #fbbf24;      /* pillar: photonics */
+  --code: #22d3ee;        /* pillar: code intelligence, used for electrical signals */
+  --ml: #a78bfa;          /* pillar: machine learning, used for acoustic / second path */
+  --quantum: #34d399;     /* pillar: quantum, used for detectors and photons */
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-display: 'Fraunces', Georgia, serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+html, body { background: var(--bg); }
+
+.reveal-viewport { background: var(--bg); }
+
+.reveal {
+  font-family: var(--font-sans);
+  font-size: 25px;
+  font-weight: 400;
+  color: var(--text);
+  line-height: 1.42;
+}
+
+.reveal .slides { text-align: left; }
+.reveal .slides section { padding: 0 24px; box-sizing: border-box; }
+
+.reveal h1, .reveal h2, .reveal h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-transform: none;
+  color: var(--text);
+  margin: 0 0 0.5em 0;
+  line-height: 1.12;
+  text-shadow: none;
+  font-variation-settings: 'opsz' 96;
+}
+.reveal h1 { font-size: 2.2em; }
+.reveal h2 { font-size: 1.45em; }
+.reveal h3 { font-size: 1.1em; }
+
+.reveal p { margin: 0 0 0.6em 0; max-width: 34em; }
+.reveal .muted { color: var(--muted); }
+.reveal .small { font-size: 0.72em; }
+.reveal strong { font-weight: 600; color: var(--text); }
+.reveal em { color: var(--accent); font-style: normal; }
+.reveal a { color: var(--accent); text-decoration: underline; text-decoration-color: color-mix(in oklab, var(--accent) 50%, transparent); text-underline-offset: 3px; }
+.reveal a:hover { text-decoration-color: var(--accent); }
+.reveal code { font-family: var(--font-mono); font-size: 0.85em; color: var(--code); background: var(--card); padding: 2px 5px; border-radius: 3px; }
+
+.reveal ul, .reveal ol { display: block; margin: 0 0 0.6em 1.1em; max-width: 34em; }
+.reveal li { margin: 0.18em 0; }
+.reveal li::marker { color: var(--accent); }
+
+/* Eyebrow: mono, uppercase, tracked. Same recipe as .book-eyebrow on the site. */
+.eyebrow {
+  max-width: none;
+  font-family: var(--font-mono);
+  font-size: 0.5em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 1.2em;
+}
+.eyebrow .num { color: var(--accent); }
+.eyebrow .sep { color: var(--strong); margin: 0 0.5em; }
+
+/* Bracket motif [ NN ] on section headings */
+.bracket {
+  font-family: var(--font-mono);
+  font-size: 0.55em;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+  vertical-align: 0.35em;
+  margin-right: 0.6em;
+  font-weight: 400;
+}
+
+/* Two-column layouts */
+.cols { display: grid; grid-template-columns: 1.05fr 1fr; gap: 40px; align-items: center; }
+.cols.wide-fig { grid-template-columns: 0.9fr 1.2fr; }
+.cols > * { min-width: 0; }
+.stack { display: flex; flex-direction: column; gap: 14px; }
+
+/* Cards */
+.card {
+  background: var(--card);
+  border: 1px solid var(--hair);
+  border-radius: 8px;
+  padding: 16px 20px;
+  font-size: 0.78em;
+}
+.card .k { font-family: var(--font-mono); font-size: 0.72em; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); display: block; margin-bottom: 4px; }
+.card.dim { opacity: 0.55; }
+
+/* Tables: the site's encoding-table recipe */
+.reveal table {
+  font-size: 0.66em;
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0;
+  font-family: var(--font-sans);
+}
+.reveal table th, .reveal table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.55em 0.8em;
+  border-bottom: 1px solid var(--hair);
+}
+.reveal table th {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-size: 0.78em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: var(--rail);
+}
+.reveal table td:first-child { font-family: var(--font-mono); color: var(--accent); font-size: 0.9em; white-space: nowrap; }
+.reveal table tr:last-child td { border-bottom: 1px solid var(--strong); }
+.reveal table tr.fragment { transition: opacity 260ms ease-out; }
+
+/* Keyboard chip */
+.kbd {
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  padding: 1px 7px;
+  background: var(--elevated);
+  border: 1px solid var(--strong);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+}
+
+/* Reveal chrome */
+.reveal .progress { height: 2px; color: var(--accent); background: var(--hair); }
+.reveal .controls { color: var(--accent); }
+.reveal .slide-number {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: var(--footnote);
+  background: transparent;
+  right: auto;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 14px;
+}
+.reveal .backgrounds .slide-background { background: var(--bg); }
+
+/* Top-of-page hairline motif */
+.reveal-viewport::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: color-mix(in oklab, var(--accent) 25%, transparent);
+  pointer-events: none;
+  z-index: 5;
+}
+
+/* Persistent deck label (bottom-left) */
+.deck-label {
+  position: fixed;
+  left: 22px;
+  bottom: 16px;
+  z-index: 6;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--footnote);
+  pointer-events: none;
+}
+.deck-label a { pointer-events: auto; color: var(--footnote); text-decoration: none; }
+.deck-label a:hover { color: var(--accent); }
+.deck-label .sep { color: var(--strong); margin: 0 0.6em; }
+
+/* ── Figures ── */
+.fig { width: 100%; height: auto; display: block; overflow: visible; }
+.fig text { font-family: var(--font-mono); font-size: 13px; fill: var(--muted); }
+.fig text.lbl { fill: var(--text); }
+.fig text.acc { fill: var(--accent); }
+.fig text.tiny { font-size: 11px; fill: var(--footnote); }
+.fig .box { fill: var(--rail); stroke: var(--strong); stroke-width: 1.5; }
+.fig .box.acc { stroke: var(--accent); }
+.fig .wire { fill: none; stroke: var(--strong); stroke-width: 1.5; }
+.fig .beam { fill: none; stroke: var(--accent); stroke-width: 2.5; stroke-linecap: round; }
+.fig .beam.faint { opacity: 0.35; }
+.fig .beam.violet { stroke: var(--ml); }
+.fig .beam.green { stroke: var(--quantum); }
+.fig .elec { fill: none; stroke: var(--code); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.fig .dot { fill: var(--accent); }
+.fig .dot.green { fill: var(--quantum); }
+.fig .dot.cyan { fill: var(--code); }
+.fig .guide { fill: color-mix(in oklab, var(--accent) 12%, transparent); stroke: color-mix(in oklab, var(--accent) 55%, transparent); stroke-width: 1.5; }
+.fig .chip { fill: var(--card); stroke: var(--strong); stroke-width: 1.5; }
+
+/* ── Animations. All keyed to `.present` (current slide) or `.fragment.visible`, so they replay on entry. ── */
+@keyframes dash-travel { to { stroke-dashoffset: 0; } }
+@keyframes flow { to { stroke-dashoffset: -48; } }
+@keyframes pulse-along { from { offset-distance: 0%; } to { offset-distance: 100%; } }
+@keyframes rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes blink { 0%, 100% { opacity: 0.2; } 50% { opacity: 1; } }
+@keyframes wobble { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-6px); } }
+@keyframes spin-phase { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@keyframes breathe { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+
+/* Drawn-in strokes: set --len on the element. */
+.draw { stroke-dasharray: var(--len, 400); stroke-dashoffset: var(--len, 400); }
+section.present .draw, .fragment.visible .draw, .fragment.visible.draw {
+  animation: dash-travel var(--dur, 1200ms) ease-out forwards;
+  animation-delay: var(--delay, 200ms);
+}
+
+/* Flowing light: moving dash pattern */
+.flowing { stroke-dasharray: 10 14; }
+section.present .flowing, .fragment.visible .flowing { animation: flow 900ms linear infinite; }
+.flowing.slow { animation-duration: 1800ms; }
+
+/* A photon riding a path via offset-path */
+.rider { offset-rotate: 0deg; opacity: 0; }
+section.present .rider, .fragment.visible .rider {
+  opacity: 1;
+  animation: pulse-along var(--dur, 2400ms) linear infinite;
+  animation-delay: var(--delay, 0ms);
+}
+
+/* Blinking detector */
+section.present .blink, .fragment.visible .blink { animation: blink 1200ms ease-in-out infinite; }
+
+.appear { opacity: 0; }
+section.present .appear, .fragment.visible .appear {
+  animation: rise 480ms ease-out forwards;
+  animation-delay: var(--delay, 200ms);
+}
+
+/* Animations inside a not-yet-revealed fragment wait for the fragment. */
+section.present .fragment:not(.visible) .draw,
+section.present .fragment:not(.visible) .rider,
+section.present .fragment:not(.visible) .flowing,
+section.present .fragment:not(.visible) .blink,
+section.present .fragment:not(.visible) .appear { animation: none; }
+
+/* Fragment styles: fade, no movement (site rule: motion is opacity or stroke only) */
+.reveal .fragment.fade-in-dim { opacity: 0.25; }
+.reveal .fragment.fade-in-dim.visible { opacity: 1; }
+
+/* Component catalogue grid */
+.catalog { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+.catalog .item { background: var(--card); border: 1px solid var(--hair); border-radius: 8px; padding: 10px 12px 8px; }
+.catalog .item svg { width: 100%; height: auto; display: block; margin-bottom: 4px; }
+.catalog .item .name { font-family: var(--font-mono); font-size: 0.55em; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); }
+.catalog .item .fn { font-size: 0.6em; color: var(--muted); line-height: 1.3; }
+
+/* MZI interactive control */
+.control { display: flex; align-items: center; gap: 16px; font-family: var(--font-mono); font-size: 0.6em; color: var(--muted); margin-top: 8px; }
+.control input[type=range] { flex: 1; accent-color: var(--accent); }
+.control output { color: var(--accent); min-width: 5.5ch; text-align: right; }
+
+/* Timeline */
+.timeline { position: relative; padding-left: 26px; margin: 0; list-style: none; }
+.timeline::before { content: ''; position: absolute; left: 6px; top: 8px; bottom: 8px; width: 1px; background: var(--strong); }
+.timeline li { position: relative; margin: 0 0 12px 0; font-size: 0.74em; line-height: 1.38; }
+.timeline li::before { content: ''; position: absolute; left: -24px; top: 0.45em; width: 9px; height: 9px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 4px var(--bg); }
+.timeline .when { font-family: var(--font-mono); font-size: 0.7em; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); display: block; }
+
+/* Title slide */
+.title-slide h1 { font-size: 2.4em; max-width: 12em; }
+.title-slide .eyebrow { margin-bottom: 2em; white-space: nowrap; }
+.title-slide .cols { grid-template-columns: 1.15fr 1fr; }
+.title-slide .fig { max-width: 520px; }
+
+/* Reduced motion: everything resolves to its final state. */
+@media (prefers-reduced-motion: reduce) {
+  .draw { stroke-dashoffset: 0; }
+  .appear, .rider { opacity: 1; }
+  .rider { offset-distance: 50%; }
+  section.present .draw, section.present .flowing, section.present .rider, section.present .blink, section.present .appear,
+  .fragment.visible .draw, .fragment.visible .flowing, .fragment.visible .rider, .fragment.visible .blink, .fragment.visible .appear {
+    animation: none;
+  }
+  .reveal table tr.fragment, .reveal .fragment { transition: none; }
+}
+
+@media (max-width: 900px) {
+  .cols, .cols.wide-fig { grid-template-columns: 1fr; gap: 20px; }
+  .catalog { grid-template-columns: repeat(2, 1fr); }
+}
+</style>
+</head>
+<body>
+
+<div class="reveal">
+<div class="slides">
+
+<!-- ═══════════════════════════════ 01 · Title ═══════════════════════════════ -->
+<section class="title-slide">
+  <p class="eyebrow"><span class="num">photonics</span><span class="sep">|</span>photonic integrated circuits<span class="sep">|</span>deck 01</p>
+  <div class="cols">
+    <div>
+      <h1>Photonic integrated circuits: an introduction</h1>
+      <p class="muted small">Where the field came from, what gets integrated, and the one design move that turns a table of optics into a circuit.</p>
+      <p class="muted small" style="margin-top:1.4em">Arrow keys to move. <span class="kbd">f</span> fullscreen. <span class="kbd">?</span> key map.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 520 260" role="img" aria-labelledby="t-title t-desc">
+      <title id="t-title">A planar chip with a waveguide carrying a light pulse from a source to a detector</title>
+      <desc id="t-desc">A rectangular substrate. A waveguide enters on the left, splits into two arms, recombines, and ends at a detector on the right. A bright dot travels along the guide.</desc>
+      <rect class="chip" x="30" y="40" width="460" height="180" rx="10"/>
+      <text x="44" y="64" class="tiny">planar substrate</text>
+      <!-- waveguide body -->
+      <path class="guide" d="M30 130 H120 C170 130 170 90 220 90 H300 C350 90 350 130 400 130 H490 V140 H400 C350 140 350 100 300 100 H220 C170 100 170 140 120 140 H30 Z"/>
+      <path class="guide" d="M120 135 C170 135 170 170 220 170 H300 C350 170 350 135 400 135 V125 C350 125 350 160 300 160 H220 C170 160 170 125 120 125 Z" style="opacity:0.75"/>
+      <!-- light -->
+      <path id="t-path" class="beam draw" style="--len:640;--dur:1600ms" d="M30 135 H120 C170 135 170 95 220 95 H300 C350 95 350 135 400 135 H490"/>
+      <path class="beam faint draw" style="--len:400;--dur:1600ms;--delay:500ms" d="M120 130 C170 130 170 165 220 165 H300 C350 165 350 130 400 130"/>
+      <circle class="dot rider" r="5" style="offset-path: path('M30 135 H120 C170 135 170 95 220 95 H300 C350 95 350 135 400 135 H490'); --dur: 2600ms"/>
+      <circle class="dot rider" r="4" style="offset-path: path('M30 135 H120 C170 130 170 165 220 165 H300 C350 165 350 130 400 130 H490'); --dur: 2600ms; --delay: 400ms; opacity:0.7"/>
+      <!-- source and detector -->
+      <rect class="box acc" x="8" y="118" width="26" height="34" rx="3"/>
+      <text x="4" y="176" class="tiny">source</text>
+      <rect class="box" x="486" y="118" width="26" height="34" rx="3"/>
+      <circle class="dot green blink" cx="499" cy="135" r="4"/>
+      <text x="472" y="176" class="tiny">detector</text>
+      <text x="222" y="212" class="tiny">guided wave, not free space</text>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 02 · Definition ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 01 ]</span><span class="sep">|</span>what integrated photonics is</p>
+  <h2>Several photonic components, one common planar substrate</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>In the broad sense, <strong>integrated photonics</strong> is the fabrication and integration of several photonic components on a common <em>planar substrate</em>.</p>
+      <p class="fragment" data-fragment-index="1">That last phrase is the whole difference from regular optics. We are talking about <strong>circuits on a planar substrate</strong>, not elements arranged on a table.</p>
+      <p class="fragment muted small" data-fragment-index="2">Each component keeps its own functionality. The platform is the integration; the components are the vocabulary.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 560 300" role="img" aria-labelledby="d-title d-desc">
+      <title id="d-title">Optical table versus planar chip</title>
+      <desc id="d-desc">Top: discrete lens, mirror, and crystal on a table with a free-space beam. Bottom: the same functions as small blocks on a single chip, linked by a waveguide.</desc>
+      <!-- table -->
+      <text x="10" y="22" class="lbl">regular optics</text>
+      <line class="wire" x1="10" y1="118" x2="550" y2="118"/>
+      <text x="470" y="136" class="tiny">optical table</text>
+      <path class="beam draw" style="--len:540;--dur:1400ms" d="M20 80 H540"/>
+      <g>
+        <path class="wire" d="M150 52 Q160 80 150 108 Q140 80 150 52 Z" style="stroke:var(--text)"/>
+        <text x="132" y="44" class="tiny">lens</text>
+        <line class="wire" x1="300" y1="50" x2="300" y2="110" style="stroke:var(--text);stroke-width:3"/>
+        <text x="282" y="44" class="tiny">filter</text>
+        <rect x="428" y="58" width="44" height="44" class="box" transform="rotate(20 450 80)"/>
+        <text x="420" y="44" class="tiny">crystal</text>
+      </g>
+      <text x="200" y="104" class="tiny" style="fill:var(--accent)">free space</text>
+      <!-- chip -->
+      <g class="fragment" data-fragment-index="1">
+        <text x="10" y="176" class="lbl">integrated photonics</text>
+        <rect class="chip" x="10" y="188" width="540" height="100" rx="8"/>
+        <path class="guide" d="M10 236 H550 V246 H10 Z"/>
+        <path class="beam draw" style="--len:540;--dur:1400ms" d="M10 241 H550"/>
+        <rect class="box acc" x="130" y="220" width="44" height="42" rx="4"/>
+        <text x="122" y="278" class="tiny">splitter</text>
+        <rect class="box acc" x="280" y="220" width="44" height="42" rx="4"/>
+        <text x="270" y="278" class="tiny">grating</text>
+        <rect class="box acc" x="430" y="220" width="44" height="42" rx="4"/>
+        <text x="418" y="278" class="tiny">modulator</text>
+        <text x="20" y="210" class="tiny" style="fill:var(--accent)">planar substrate + waveguide</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 03 · Component catalogue ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 02 ]</span><span class="sep">|</span>the component vocabulary</p>
+  <h2>What can be put on the substrate</h2>
+  <div class="catalog">
+    <div class="item fragment fade-in-dim" data-fragment-index="1">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 30 H50"/><path class="beam" d="M50 30 Q70 30 80 16 H116"/><path class="beam" d="M50 30 Q70 30 80 44 H116"/></svg>
+      <div class="name">splitter / combiner</div>
+      <div class="fn">One beam in, two out. Reciprocal: run it backwards to combine.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="2">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 30 H40"/><g class="wire" style="stroke:var(--text)"><line x1="46" y1="14" x2="46" y2="46"/><line x1="56" y1="14" x2="56" y2="46"/><line x1="66" y1="14" x2="66" y2="46"/><line x1="76" y1="14" x2="76" y2="46"/></g><path class="beam" d="M82 30 H116"/><path class="beam faint" d="M82 30 L116 12"/><path class="beam faint" d="M82 30 L116 48"/></svg>
+      <div class="name">grating</div>
+      <div class="fn">Filters light by wavelength; the diffraction workhorse.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="3">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 20 H116"/><path class="beam faint" d="M4 44 H116"/><path class="beam" d="M40 20 C60 20 60 44 80 44" style="stroke-width:1.5"/></svg>
+      <div class="name">coupler</div>
+      <div class="fn">Moves light between two components or two guides.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="4">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 30 H44"/><path class="beam violet" d="M4 22 H44" style="opacity:0.7"/><rect x="48" y="12" width="24" height="36" class="box"/><line x1="60" y1="16" x2="60" y2="44" class="wire" style="stroke:var(--text)"/><path class="beam" d="M76 30 H116"/></svg>
+      <div class="name">polariser</div>
+      <div class="fn">Selects or rotates one polarisation out of a scrambled input.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="5">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 30 H24 Q40 30 46 16 H74 Q90 30 96 30 H116"/><path class="beam" d="M24 30 Q40 30 46 44 H74 Q90 30 96 30"/></svg>
+      <div class="name">interferometer</div>
+      <div class="fn">Split, propagate, recombine. Already a small circuit.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="6">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><rect x="8" y="16" width="30" height="28" class="box acc"/><path class="beam" d="M38 30 H116"/><circle class="dot" cx="70" cy="30" r="3"/><circle class="dot" cx="96" cy="30" r="3"/></svg>
+      <div class="name">light source</div>
+      <div class="fn">Generates photons on chip.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="7">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 30 H82"/><rect x="82" y="16" width="30" height="28" class="box"/><circle class="dot green" cx="97" cy="30" r="4"/></svg>
+      <div class="name">detector</div>
+      <div class="fn">Generated photons have to be counted somewhere.</div>
+    </div>
+    <div class="item fragment fade-in-dim" data-fragment-index="8">
+      <svg class="fig" viewBox="0 0 120 60" aria-hidden="true"><path class="beam" d="M4 30 H36"/><rect x="40" y="14" width="40" height="32" class="box"/><path class="elec" d="M44 8 L52 8 L52 2 L60 2 L60 8 L68 8"/><path class="beam" d="M84 30 H116"/></svg>
+      <div class="name">and more</div>
+      <div class="fn">Modulators, amplifiers, phase shifters, resonators.</div>
+    </div>
+  </div>
+  <p class="muted small fragment" data-fragment-index="9" style="margin-top:14px">Each block has one functionality. Integrated photonics is the platform that lets several of them share one substrate.</p>
+</section>
+
+<!-- ═══════════════════════════════ 04 · Splitter / combiner ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 03 ]</span><span class="sep">|</span>a discrete element</p>
+  <h2>Beam splitting is reciprocal</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>A <strong>beam splitter</strong> takes a single beam and produces two. Power splitting in one direction.</p>
+      <p class="fragment" data-fragment-index="1">Run the same device the other way and it is a <strong>combiner</strong>. Splitting and combining are one reciprocal functionality.</p>
+      <p class="fragment muted small" data-fragment-index="2">Splitter, grating, coupler, polariser: each of these is a discrete element. None of them is yet a circuit.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 520 240" role="img" aria-labelledby="s-title s-desc">
+      <title id="s-title">Y-junction splitter, then the same junction used as a combiner</title>
+      <desc id="s-desc">Top: one waveguide enters from the left and forks into two. Bottom: two waveguides enter from the left and merge into one.</desc>
+      <text x="10" y="22" class="lbl">split</text>
+      <path class="guide" d="M10 60 H180 C230 60 240 34 300 34 H510 V46 H300 C250 46 240 72 180 72 H10 Z"/>
+      <path class="guide" d="M180 66 C240 66 250 92 300 92 H510 V104 H300 C240 104 230 78 180 78 Z"/>
+      <path class="beam draw" style="--len:520;--dur:1300ms" d="M10 69 H180 C230 69 240 40 300 40 H510"/>
+      <path class="beam draw" style="--len:520;--dur:1300ms" d="M10 69 H180 C240 69 250 98 300 98 H510"/>
+      <circle class="dot rider" r="5" style="offset-path: path('M10 69 H180 C230 69 240 40 300 40 H510'); --dur: 2000ms"/>
+      <circle class="dot rider" r="5" style="offset-path: path('M10 69 H180 C240 69 250 98 300 98 H510'); --dur: 2000ms"/>
+      <text x="14" y="52" class="tiny">P</text>
+      <text x="470" y="30" class="tiny acc">P / 2</text>
+      <text x="470" y="122" class="tiny acc">P / 2</text>
+      <g class="fragment" data-fragment-index="1">
+        <text x="10" y="154" class="lbl">combine</text>
+        <path class="guide" d="M510 200 H340 C290 200 280 174 220 174 H10 V186 H220 C270 186 280 212 340 212 H510 Z"/>
+        <path class="guide" d="M340 206 C280 206 270 232 220 232 H10 V220 H220 C280 220 290 218 340 218 Z"/>
+        <path class="beam draw" style="--len:520;--dur:1300ms;--delay:100ms" d="M10 180 H220 C270 180 280 206 340 206 H510"/>
+        <path class="beam draw" style="--len:520;--dur:1300ms;--delay:100ms" d="M10 226 H220 C280 226 290 206 340 206 H510"/>
+        <circle class="dot rider" r="5" style="offset-path: path('M10 180 H220 C270 180 280 206 340 206 H510'); --dur: 2000ms"/>
+        <circle class="dot rider" r="5" style="offset-path: path('M10 226 H220 C280 226 290 206 340 206 H510'); --dur: 2000ms"/>
+        <text x="470" y="196" class="tiny acc">P</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 05 · Interferometer (interactive) ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 04 ]</span><span class="sep">|</span>the first circuit</p>
+  <h2>An interferometer is already a circuit</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>Divide the light in two, let each half propagate along its own path, then put them back together. The two beams <strong>interfere</strong>.</p>
+      <p class="muted small">Change the relative phase between the arms and the output swings between bright and dark. Drag to try it.</p>
+      <div class="control">
+        <span>phase</span>
+        <input id="mzi-phase" type="range" min="0" max="360" value="0" step="1" aria-label="Relative phase between the arms, in degrees">
+        <output id="mzi-out">0&deg;</output>
+      </div>
+      <div class="control"><span>output</span><span id="mzi-bar" style="flex:1;height:8px;background:var(--rail);border-radius:4px;overflow:hidden"><span id="mzi-fill" style="display:block;height:100%;width:100%;background:var(--accent)"></span></span><output id="mzi-i">1.00</output></div>
+    </div>
+    <svg class="fig" viewBox="0 0 520 220" role="img" aria-labelledby="m-title m-desc">
+      <title id="m-title">Mach-Zehnder interferometer with an adjustable phase in one arm</title>
+      <desc id="m-desc">A waveguide splits into an upper and lower arm. The lower arm carries a phase shifter. The arms recombine and the output brightness depends on the phase difference.</desc>
+      <path class="guide" d="M10 104 H100 C150 104 150 44 200 44 H320 C370 44 370 104 420 104 H510 V116 H420 C370 116 370 56 320 56 H200 C150 56 150 116 100 116 H10 Z"/>
+      <path class="guide" d="M100 110 C150 110 150 170 200 170 H320 C370 170 370 110 420 110 V104 C370 104 370 164 320 164 H200 C150 164 150 104 100 104 Z" style="opacity:0.8"/>
+      <path class="beam flowing" d="M10 110 H100 C150 110 150 50 200 50 H320 C370 50 370 110 420 110"/>
+      <path class="beam flowing violet" id="mzi-arm2" d="M100 110 C150 110 150 167 200 167 H320 C370 167 370 110 420 110"/>
+      <path class="beam" id="mzi-outbeam" d="M420 110 H510"/>
+      <!-- phase shifter -->
+      <rect class="box acc" x="230" y="150" width="60" height="34" rx="4"/>
+      <text x="238" y="171" class="tiny acc" id="mzi-phi">phi</text>
+      <text x="216" y="200" class="tiny">phase shifter</text>
+      <text x="236" y="36" class="tiny">arm 1</text>
+      <text x="14" y="94" class="tiny">in</text>
+      <text x="480" y="94" class="tiny acc">out</text>
+      <!-- detector -->
+      <rect class="box" x="506" y="94" width="10" height="32" rx="2"/>
+      <circle id="mzi-det" class="dot green" cx="511" cy="110" r="4"/>
+      <!-- fringe indicator -->
+      <g transform="translate(430 150)">
+        <text x="0" y="0" class="tiny">I = cos^2(phi / 2)</text>
+        <path class="wire" d="M0 40 C15 10 25 10 40 40 S65 70 80 40" style="stroke:var(--strong)"/>
+        <circle id="mzi-marker" class="dot" cx="0" cy="40" r="4"/>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 06 · Sources and detectors ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 05 ]</span><span class="sep">|</span>closing the loop</p>
+  <h2>Generate photons, then count them</h2>
+  <div class="cols">
+    <div class="stack">
+      <p>A <strong>light source</strong> on chip generates photons. Once photons exist, they have to be detected, so a <strong>detector</strong> is the matching on-chip component.</p>
+      <p class="fragment" data-fragment-index="1">Source, waveguide, functional blocks, detector. That chain is what makes the substrate a <em>platform</em> and not a parts bin.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 480 200" role="img" aria-labelledby="g-title g-desc">
+      <title id="g-title">Source to detector chain on one chip</title>
+      <desc id="g-desc">A source block emits photons into a waveguide; they pass a functional block and arrive at a detector, which produces an electrical pulse.</desc>
+      <rect class="chip" x="10" y="30" width="460" height="140" rx="8"/>
+      <path class="guide" d="M70 96 H400 V108 H70 Z"/>
+      <rect class="box acc" x="30" y="80" width="42" height="44" rx="4"/>
+      <text x="26" y="146" class="tiny">source</text>
+      <rect class="box" x="210" y="80" width="60" height="44" rx="4"/>
+      <text x="204" y="146" class="tiny">function</text>
+      <rect class="box" x="400" y="80" width="42" height="44" rx="4"/>
+      <text x="388" y="146" class="tiny">detector</text>
+      <circle class="dot rider" r="4" style="offset-path: path('M72 102 H400'); --dur: 1800ms"/>
+      <circle class="dot rider" r="4" style="offset-path: path('M72 102 H400'); --dur: 1800ms; --delay: 600ms"/>
+      <circle class="dot rider" r="4" style="offset-path: path('M72 102 H400'); --dur: 1800ms; --delay: 1200ms"/>
+      <circle class="dot green blink" cx="421" cy="102" r="5"/>
+      <g class="fragment" data-fragment-index="1">
+        <path class="elec draw" style="--len:120;--dur:800ms" d="M442 102 H452 V70 H458 V102 H466"/>
+        <text x="420" y="60" class="tiny" style="fill:var(--code)">electrons out</text>
+        <path class="elec draw" style="--len:120;--dur:800ms" d="M14 102 H20 V70 H26 V102 H30"/>
+        <text x="14" y="60" class="tiny" style="fill:var(--code)">electrons in</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 07 · Optics, defined ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 06 ]</span><span class="sep">|</span>historic perspective</p>
+  <h2>Optics: generation, propagation, interaction</h2>
+  <div class="cols">
+    <div class="stack">
+      <p>Optics is the branch of physical science that deals with the <strong>generation</strong> and <strong>propagation</strong> of light and its <strong>interaction with matter</strong>. Light science, in short.</p>
+      <ul class="small">
+        <li class="fragment" data-fragment-index="1">Lenses collimate a diverging beam: control of propagation.</li>
+        <li class="fragment" data-fragment-index="2">In an <strong>isotropic</strong> medium light sees no direction; in an <strong>anisotropic</strong> crystal the propagation depends on direction. Linear and nonlinear crystals are the interaction half.</li>
+      </ul>
+    </div>
+    <svg class="fig" viewBox="0 0 480 240" role="img" aria-labelledby="o-title o-desc">
+      <title id="o-title">Three constituents of optics: generate, propagate, interact</title>
+      <desc id="o-desc">A source emits a diverging beam, a lens collimates it, and the collimated beam enters a crystal where the ray splits in two.</desc>
+      <rect class="box acc" x="16" y="96" width="34" height="34" rx="4"/>
+      <text x="8" y="150" class="tiny">generate</text>
+      <!-- diverging rays -->
+      <g class="beam" style="stroke-width:1.5">
+        <path class="draw" style="--len:140;--dur:900ms" d="M50 113 L170 113"/>
+        <path class="draw" style="--len:140;--dur:900ms" d="M50 113 L170 78"/>
+        <path class="draw" style="--len:140;--dur:900ms" d="M50 113 L170 148"/>
+      </g>
+      <!-- lens -->
+      <g class="fragment" data-fragment-index="1">
+        <path class="wire" d="M175 60 Q192 113 175 166 Q158 113 175 60 Z" style="stroke:var(--text)"/>
+        <text x="150" y="190" class="tiny">propagate</text>
+        <g class="beam" style="stroke-width:1.5">
+          <path class="draw" style="--len:140;--dur:900ms" d="M178 78 H320"/>
+          <path class="draw" style="--len:140;--dur:900ms" d="M178 113 H320"/>
+          <path class="draw" style="--len:140;--dur:900ms" d="M178 148 H320"/>
+        </g>
+        <text x="220" y="66" class="tiny acc">collimated</text>
+      </g>
+      <!-- crystal -->
+      <g class="fragment" data-fragment-index="2">
+        <rect class="box" x="322" y="70" width="70" height="86"/>
+        <text x="318" y="190" class="tiny">interact</text>
+        <g class="beam" style="stroke-width:1.5">
+          <path class="draw" style="--len:120;--dur:900ms" d="M322 113 L392 100 L470 88"/>
+          <path class="violet draw" style="--len:120;--dur:900ms;--delay:400ms" d="M322 113 L392 126 L470 140"/>
+        </g>
+        <text x="330" y="62" class="tiny">anisotropic</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 08 · Three innovations ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 07 ]</span><span class="sep">|</span>historic perspective</p>
+  <h2>Three inventions made modern optics</h2>
+  <div class="cols">
+    <ol class="timeline">
+      <li class="fragment" data-fragment-index="1"><span class="when">one</span><strong>The laser.</strong> Highly spatially and temporally coherent light with very high brightness. Coherence plus brightness opened optical signal processing and a new way to study materials.</li>
+      <li class="fragment" data-fragment-index="2"><span class="when">two</span><strong>Semiconductor optical devices.</strong> Microelectronics and compound-semiconductor materials science met optics. Direct band gap materials generate and detect photons efficiently; the term <em>optoelectronic</em> arrives.</li>
+      <li class="fragment" data-fragment-index="3"><span class="when">three</span><strong>Cheap, low-loss optical fiber.</strong> Not just the invention but the fabrication: transport light from A to B without losing it. Loss today sits near the theoretical, material-limited floor.</li>
+    </ol>
+    <svg class="fig" viewBox="0 0 400 300" role="img" aria-labelledby="i-title i-desc">
+      <title id="i-title">Laser, semiconductor device, and fiber as three stacked panels</title>
+      <desc id="i-desc">Panel one: a coherent beam of aligned wavefronts. Panel two: a band diagram with an electron dropping across the gap and emitting a photon. Panel three: a fiber carrying a pulse a long distance with almost no attenuation.</desc>
+      <g class="fragment" data-fragment-index="1">
+        <text x="8" y="22" class="tiny">laser: coherent, bright</text>
+        <rect class="box acc" x="8" y="34" width="40" height="30" rx="3"/>
+        <g class="beam" style="stroke-width:1.5">
+          <path class="draw" style="--len:340;--dur:1000ms" d="M48 49 H390"/>
+        </g>
+        <g class="wire" style="stroke:var(--accent);opacity:0.6">
+          <line x1="90" y1="38" x2="90" y2="60"/><line x1="130" y1="38" x2="130" y2="60"/><line x1="170" y1="38" x2="170" y2="60"/><line x1="210" y1="38" x2="210" y2="60"/><line x1="250" y1="38" x2="250" y2="60"/><line x1="290" y1="38" x2="290" y2="60"/><line x1="330" y1="38" x2="330" y2="60"/><line x1="370" y1="38" x2="370" y2="60"/>
+        </g>
+      </g>
+      <g class="fragment" data-fragment-index="2">
+        <text x="8" y="112" class="tiny">semiconductor: e- to photon</text>
+        <line class="wire" x1="20" y1="126" x2="180" y2="126" style="stroke:var(--text)"/>
+        <line class="wire" x1="20" y1="176" x2="180" y2="176" style="stroke:var(--text)"/>
+        <text x="186" y="130" class="tiny">E_c</text>
+        <text x="186" y="180" class="tiny">E_v</text>
+        <circle class="dot cyan rider" r="5" style="offset-path: path('M100 126 V176'); --dur: 1600ms"/>
+        <path class="beam draw" style="--len:200;--dur:1000ms;--delay:600ms" d="M110 151 q10 -8 20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0"/>
+        <text x="300" y="140" class="tiny acc">photon</text>
+      </g>
+      <g class="fragment" data-fragment-index="3">
+        <text x="8" y="226" class="tiny">fiber: low loss over distance</text>
+        <path class="guide" d="M8 250 H392 V266 H8 Z"/>
+        <path class="beam draw" style="--len:390;--dur:1400ms" d="M8 258 H392"/>
+        <circle class="dot rider" r="5" style="offset-path: path('M8 258 H392'); --dur: 2600ms"/>
+        <text x="250" y="290" class="tiny">near the material limit</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 09 · Band gaps ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 08 ]</span><span class="sep">|</span>semiconductor optical devices</p>
+  <h2>Direct versus indirect band gap</h2>
+  <div class="cols">
+    <div class="stack">
+      <table>
+        <thead><tr><th>material</th><th>emit photons</th><th>detect photons</th><th>role in photonics</th></tr></thead>
+        <tbody>
+          <tr class="fragment" data-fragment-index="1"><td>direct gap</td><td>efficient</td><td>efficient</td><td>lasers, LEDs, detectors</td></tr>
+          <tr class="fragment" data-fragment-index="2"><td>indirect gap</td><td>inefficient</td><td>usable</td><td>detectors, not sources</td></tr>
+        </tbody>
+      </table>
+      <p class="fragment small" data-fragment-index="3">Compound semiconductors let the <strong>composition</strong> tune the band gap. Engineering the material generates <em>new wavelengths</em> that were simply unavailable before. Rich for materials science, useful for applications: efficient and compact optoelectronic devices.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 440 260" role="img" aria-labelledby="b-title b-desc">
+      <title id="b-title">E versus k for direct and indirect band gaps</title>
+      <desc id="b-desc">Left: conduction-band minimum directly above the valence-band maximum, an electron drops vertically and emits a photon. Right: the minimum is displaced in k, so the transition needs a phonon and is inefficient.</desc>
+      <g class="fragment" data-fragment-index="1">
+        <text x="30" y="20" class="lbl">direct</text>
+        <path class="wire" d="M30 250 V40 M30 250 H200" style="stroke:var(--strong)"/>
+        <text x="16" y="52" class="tiny">E</text><text x="190" y="246" class="tiny">k</text>
+        <path class="wire" d="M50 90 Q115 30 180 90" style="stroke:var(--text)"/>
+        <path class="wire" d="M50 170 Q115 230 180 170" style="stroke:var(--text)"/>
+        <circle class="dot cyan rider" r="5" style="offset-path: path('M115 60 V200'); --dur: 1600ms"/>
+        <path class="beam draw" style="--len:120;--dur:800ms;--delay:700ms" d="M122 130 q8 -6 16 0 t16 0 t16 0 t16 0 t16 0"/>
+        <text x="132" y="118" class="tiny acc">hv</text>
+      </g>
+      <g class="fragment" data-fragment-index="2">
+        <text x="250" y="20" class="lbl">indirect</text>
+        <path class="wire" d="M250 250 V40 M250 250 H420" style="stroke:var(--strong)"/>
+        <text x="236" y="52" class="tiny">E</text><text x="410" y="246" class="tiny">k</text>
+        <path class="wire" d="M270 110 Q335 30 400 80" style="stroke:var(--text)"/>
+        <path class="wire" d="M270 170 Q335 230 400 170" style="stroke:var(--text)"/>
+        <circle class="dot cyan rider" r="5" style="offset-path: path('M382 78 L335 200'); --dur: 1600ms"/>
+        <path class="wire draw" style="--len:80;--dur:800ms;--delay:600ms;stroke:var(--ml);stroke-dasharray:4 4" d="M382 78 L335 200"/>
+        <text x="352" y="150" class="tiny" style="fill:var(--ml)">needs phonon</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 10 · Optics to photonics ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 09 ]</span><span class="sep">|</span>what pushed optics toward photonics</p>
+  <h2>From studying light to manipulating it</h2>
+  <svg class="fig" viewBox="0 0 900 250" role="img" aria-labelledby="f-title f-desc" style="max-width:100%">
+    <title id="f-title">Flow from classical optics through semiconductor and fiber technology into photonics</title>
+    <desc id="f-desc">Four boxes connected left to right: classical optics; semiconductor technology plus the ability to transport light; new components such as lasers, detectors, modulators; and photonics, which unites the science of light with its manipulation.</desc>
+    <g class="appear" style="--delay:100ms">
+      <rect class="box" x="10" y="60" width="190" height="120" rx="8"/>
+      <text x="26" y="88" class="lbl">classical optics</text>
+      <text x="26" y="114" class="tiny">lenses</text><text x="26" y="132" class="tiny">mirrors</text><text x="26" y="150" class="tiny">filters</text>
+    </g>
+    <path class="beam draw" style="--len:60;--dur:500ms;--delay:600ms" d="M200 120 H240"/>
+    <g class="appear" style="--delay:900ms">
+      <rect class="box" x="240" y="60" width="200" height="120" rx="8"/>
+      <text x="256" y="88" class="lbl">two advances</text>
+      <text x="256" y="114" class="tiny">semiconductor tech:</text><text x="256" y="130" class="tiny">lasers and detectors</text>
+      <text x="256" y="152" class="tiny">transport: optical fiber</text>
+    </g>
+    <path class="beam draw" style="--len:60;--dur:500ms;--delay:1400ms" d="M440 120 H480"/>
+    <g class="appear" style="--delay:1700ms">
+      <rect class="box" x="480" y="60" width="180" height="120" rx="8"/>
+      <text x="496" y="88" class="lbl">new components</text>
+      <text x="496" y="114" class="tiny">semiconductor lasers</text><text x="496" y="132" class="tiny">detectors</text><text x="496" y="150" class="tiny">modulators (for information)</text>
+    </g>
+    <path class="beam draw" style="--len:60;--dur:500ms;--delay:2200ms" d="M660 120 H700"/>
+    <g class="appear" style="--delay:2500ms">
+      <rect class="box acc" x="700" y="60" width="190" height="120" rx="8"/>
+      <text x="716" y="88" class="acc">photonics</text>
+      <text x="716" y="114" class="tiny">science of light</text>
+      <text x="716" y="132" class="tiny">+ manipulation of light</text>
+      <text x="716" y="150" class="tiny">the broader term today</text>
+    </g>
+  </svg>
+  <p class="small muted" style="margin-top:20px">Photonics grew out of its narrow definition (photons interacting with electrons) into the umbrella term for general optical functionality. Nobody says optics much any more; everything is photonics.</p>
+</section>
+
+<!-- ═══════════════════════════════ 11 · Faces of photonics (table) ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 10 ]</span><span class="sep">|</span>the faces of photonics</p>
+  <h2>Four sub-fields, one question each: what controls the light?</h2>
+  <table>
+    <thead><tr><th>sub-field</th><th>control knob</th><th>what happens</th><th>example device</th></tr></thead>
+    <tbody>
+      <tr class="fragment" data-fragment-index="1"><td>electro-optics</td><td>electric field or current</td><td>flow of light is controlled electrically</td><td>modulator, electro-absorption</td></tr>
+      <tr class="fragment" data-fragment-index="2"><td>acousto-optics</td><td>acoustic wave (piezo or phonons)</td><td>acoustic wave steers or filters the light</td><td>acousto-optic deflector</td></tr>
+      <tr class="fragment" data-fragment-index="3"><td>opto-electronics</td><td>electron processes</td><td>electronic process ends in photon generation or starts from photon detection</td><td>LED, semiconductor laser, photodetector</td></tr>
+      <tr class="fragment" data-fragment-index="4"><td>quantum optics</td><td>single photons</td><td>generate, manipulate, interfere, and detect individual photons</td><td>single-photon source, QKD link, optical amplifier</td></tr>
+    </tbody>
+  </table>
+  <p class="fragment small muted" data-fragment-index="5" style="margin-top:18px">Opto-electronics sits on the border between electronics and photonics, which is exactly why it is a good example of the two fields merging.</p>
+</section>
+
+<!-- ═══════════════════════════════ 12 · Electro-optics ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 11 ]</span><span class="sep">|</span>electro-optics</p>
+  <h2>An electrical signal, printed onto light</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>Take a <strong>continuous wave</strong> and change its intensity electrically.</p>
+      <ul class="small">
+        <li class="fragment" data-fragment-index="1"><strong>Direct modulation:</strong> change the current driving the laser.</li>
+        <li class="fragment" data-fragment-index="2"><strong>Electro-absorption:</strong> the material's absorption follows the applied field, so the output intensity follows the electrical pulse.</li>
+      </ul>
+    </div>
+    <svg class="fig" viewBox="0 0 520 250" role="img" aria-labelledby="e-title e-desc">
+      <title id="e-title">Electro-absorption modulator</title>
+      <desc id="e-desc">A flat continuous-wave input enters a modulator block driven by a square electrical pulse; the output intensity is a copy of the electrical pulse.</desc>
+      <text x="10" y="24" class="tiny">CW in (constant intensity)</text>
+      <path class="beam flowing slow" d="M10 70 H180"/>
+      <path class="wire" d="M10 46 H180" style="stroke:var(--accent);opacity:0.5"/>
+      <text x="10" y="100" class="tiny">I</text>
+      <rect class="box acc" x="190" y="30" width="120" height="80" rx="6"/>
+      <text x="210" y="62" class="lbl">electro-</text><text x="210" y="82" class="lbl">absorption</text>
+      <!-- electrical drive -->
+      <g class="fragment" data-fragment-index="2">
+        <path class="elec draw" style="--len:260;--dur:1200ms" d="M190 200 H220 V160 H250 V200 H270 V160 H290 V200 H310"/>
+        <line class="wire" x1="250" y1="112" x2="250" y2="156" style="stroke:var(--code)"/>
+        <text x="186" y="230" class="tiny" style="fill:var(--code)">electrical pulse V(t)</text>
+        <!-- output follows -->
+        <path class="beam draw" style="--len:260;--dur:1200ms;--delay:400ms" d="M320 70 H350 V46 H380 V70 H400 V46 H420 V70 H510"/>
+        <text x="322" y="24" class="tiny acc">out follows V(t)</text>
+        <circle class="dot rider" r="4" style="offset-path: path('M320 70 H350 V46 H380 V70 H400 V46 H420 V70 H510'); --dur: 2200ms"/>
+      </g>
+      <g class="fragment" data-fragment-index="1">
+        <text x="10" y="150" class="tiny">or: drive the laser current</text>
+        <rect class="box acc" x="10" y="160" width="34" height="34" rx="3"/>
+        <path class="elec draw" style="--len:100;--dur:900ms" d="M10 230 H20 V212 H30 V230 H40 V212 H50"/>
+        <path class="beam draw" style="--len:120;--dur:900ms;--delay:300ms" d="M44 177 H60 V165 H80 V177 H100 V165 H120 V177 H160"/>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 13 · Acousto-optics ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 12 ]</span><span class="sep">|</span>acousto-optics</p>
+  <h2>Sound waves as a tunable grating</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>If an electric field can steer light, so can an <strong>acoustic wave</strong>. A piezo-electric transducer launches a pressure wave into the crystal; its periodic density is a grating that light diffracts from.</p>
+      <p class="fragment small" data-fragment-index="1">The acoustic wave can also come from <strong>phonons</strong> in the material rather than a transducer. Different origin, same interaction: acoustic wave meets light wave.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 520 250" role="img" aria-labelledby="a-title a-desc">
+      <title id="a-title">Acousto-optic deflector</title>
+      <desc id="a-desc">A transducer on the side of a crystal launches vertical acoustic wavefronts. An incoming beam crosses them and a diffracted beam leaves at an angle.</desc>
+      <rect class="box" x="140" y="40" width="240" height="170"/>
+      <text x="150" y="30" class="tiny">crystal</text>
+      <rect class="box" x="140" y="212" width="240" height="14" style="fill:var(--ml);stroke:none;opacity:0.7"/>
+      <text x="196" y="244" class="tiny" style="fill:var(--ml)">piezo-electric transducer</text>
+      <path class="elec draw" style="--len:60;--dur:600ms" d="M100 219 H140"/>
+      <text x="40" y="224" class="tiny" style="fill:var(--code)">RF drive</text>
+      <!-- acoustic fronts -->
+      <g style="stroke:var(--ml);stroke-width:1.5;fill:none;opacity:0.6">
+        <line class="flowing slow" x1="150" y1="200" x2="370" y2="200"/>
+        <line class="flowing slow" x1="150" y1="170" x2="370" y2="170"/>
+        <line class="flowing slow" x1="150" y1="140" x2="370" y2="140"/>
+        <line class="flowing slow" x1="150" y1="110" x2="370" y2="110"/>
+        <line class="flowing slow" x1="150" y1="80" x2="370" y2="80"/>
+        <line class="flowing slow" x1="150" y1="50" x2="370" y2="50"/>
+      </g>
+      <text x="386" y="130" class="tiny" style="fill:var(--ml)">acoustic wave</text>
+      <!-- light -->
+      <path class="beam draw" style="--len:400;--dur:1200ms" d="M10 125 L260 125 L510 125"/>
+      <path class="beam draw" style="--len:260;--dur:1000ms;--delay:600ms" d="M260 125 L510 60"/>
+      <text x="470" y="52" class="tiny acc">deflected</text>
+      <text x="470" y="148" class="tiny">undeflected</text>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 14 · Opto-electronics + quantum optics ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 13 ]</span><span class="sep">|</span>opto-electronics and quantum optics</p>
+  <h2>Electrons in, photons out. And then single photons.</h2>
+  <div class="cols">
+    <div class="stack">
+      <div class="card">
+        <span class="k">opto-electronics</span>
+        The process runs in the electronic domain but ends in <strong>photon generation</strong>, or begins because a <strong>photon was detected</strong>. Semiconductor LEDs, lasers, and detectors.
+      </div>
+      <div class="card fragment" data-fragment-index="1">
+        <span class="k">quantum optics</span>
+        Stop treating light as a photon flux. Generate a <strong>single photon</strong>, set its polarisation, interfere two photons of different states, detect it. Applications: secure key distribution, optical computing, imaging, sensing.
+      </div>
+      <p class="fragment small muted" data-fragment-index="2">Optical amplifiers are quantum devices. Strictly, every photonic process is explained by quantum mechanics; quantum optics is where that stops being a footnote.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 440 260" role="img" aria-labelledby="q-title q-desc">
+      <title id="q-title">Two directions of opto-electronics, then a single-photon experiment</title>
+      <desc id="q-desc">Top: electrons enter a device and photons leave; photons enter a second device and electrons leave. Bottom: one photon enters a beam splitter and is detected at one of two outputs.</desc>
+      <text x="8" y="20" class="tiny">electrons to photons</text>
+      <path class="elec draw" style="--len:80;--dur:700ms" d="M8 50 H20 V34 H30 V50 H40 V34 H50 V50 H60"/>
+      <rect class="box acc" x="64" y="30" width="50" height="40" rx="4"/>
+      <text x="70" y="55" class="tiny">LED</text>
+      <circle class="dot rider" r="4" style="offset-path: path('M114 50 H200'); --dur: 1400ms"/>
+      <circle class="dot rider" r="4" style="offset-path: path('M114 50 H200'); --dur: 1400ms; --delay: 500ms"/>
+      <text x="236" y="20" class="tiny">photons to electrons</text>
+      <circle class="dot rider" r="4" style="offset-path: path('M236 50 H320'); --dur: 1400ms"/>
+      <rect class="box" x="322" y="30" width="50" height="40" rx="4"/>
+      <circle class="dot green blink" cx="347" cy="50" r="4"/>
+      <path class="elec draw" style="--len:80;--dur:700ms;--delay:700ms" d="M372 50 H384 V34 H394 V50 H404 V34 H414 V50 H430"/>
+      <g class="fragment" data-fragment-index="1">
+        <text x="8" y="130" class="tiny">one photon at a time</text>
+        <path class="guide" d="M8 176 H150 V186 H8 Z"/>
+        <path class="guide" d="M150 176 C190 176 190 140 230 140 H330 V150 H230 C200 150 200 186 150 186 Z"/>
+        <path class="guide" d="M150 176 C190 176 190 212 230 212 H330 V222 H230 C200 222 200 186 150 186 Z"/>
+        <circle class="dot rider" r="5" style="offset-path: path('M8 181 H150 C190 181 190 145 230 145 H330'); --dur: 2400ms"/>
+        <rect class="box" x="330" y="130" width="16" height="30" rx="2"/><circle class="dot green blink" cx="338" cy="145" r="4"/>
+        <rect class="box" x="330" y="202" width="16" height="30" rx="2"/><circle class="dot green" cx="338" cy="217" r="4" style="opacity:0.25"/>
+        <text x="356" y="150" class="tiny acc">click</text>
+        <text x="356" y="222" class="tiny">silent</text>
+        <text x="150" y="250" class="tiny">a single photon does not split; it is found at one detector</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 15 · Application disciplines ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 14 ]</span><span class="sep">|</span>application disciplines</p>
+  <h2>Generate, transport, manipulate: the applications follow</h2>
+  <svg class="fig" viewBox="0 0 900 230" role="img" aria-labelledby="p-title p-desc" style="max-width:100%">
+    <title id="p-title">Three capabilities feeding four application areas</title>
+    <desc id="p-desc">Three source nodes (generate light, transport light, manipulate light) on the left fan out to four application nodes on the right: optical communication, imaging and display, optical computing, optical sensing.</desc>
+    <g class="appear" style="--delay:100ms">
+      <rect class="box acc" x="10" y="20" width="200" height="44" rx="6"/><text x="26" y="48" class="lbl">generate light</text>
+      <rect class="box acc" x="10" y="92" width="200" height="44" rx="6"/><text x="26" y="120" class="lbl">transport light</text>
+      <rect class="box acc" x="10" y="164" width="200" height="44" rx="6"/><text x="26" y="192" class="lbl">manipulate light</text>
+    </g>
+    <g class="beam" style="stroke-width:1.5;opacity:0.7">
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:500ms" d="M210 42 C400 42 450 32 640 32"/>
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:600ms" d="M210 114 C400 114 450 32 640 32"/>
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:700ms" d="M210 186 C400 186 450 84 640 84"/>
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:800ms" d="M210 42 C400 42 450 84 640 84"/>
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:900ms" d="M210 186 C400 186 450 136 640 136"/>
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:1000ms" d="M210 114 C400 114 450 188 640 188"/>
+      <path class="draw" style="--len:500;--dur:1200ms;--delay:1100ms" d="M210 42 C400 42 450 188 640 188"/>
+    </g>
+    <g class="appear" style="--delay:1500ms">
+      <rect class="box" x="640" y="10" width="250" height="44" rx="6"/><text x="656" y="38" class="lbl">optical communication</text>
+      <rect class="box" x="640" y="62" width="250" height="44" rx="6"/><text x="656" y="90" class="lbl">imaging and display</text>
+      <rect class="box" x="640" y="114" width="250" height="44" rx="6"/><text x="656" y="142" class="lbl">optical computing</text>
+      <rect class="box" x="640" y="166" width="250" height="44" rx="6"/><text x="656" y="194" class="lbl">optical sensing</text>
+    </g>
+  </svg>
+  <p class="small muted" style="margin-top:20px">Short-distance and long-distance data communication were enabled by photonics and are studied as part of it. The rest of the list exists because we learned to generate, transport, and manipulate light well.</p>
+</section>
+
+<!-- ═══════════════════════════════ 16 · Integrated photonics history ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 15 ]</span><span class="sep">|</span>integrated photonics, historically</p>
+  <h2>The term is older than you think</h2>
+  <div class="cols">
+    <ol class="timeline">
+      <li class="fragment" data-fragment-index="1"><span class="when">1960s</span><strong>The proposal.</strong> Emphasise the similarity between planar circuit technology and the well established integrated microelectronic circuit. Optical benches look like circuits; why not build them like one?</li>
+      <li class="fragment" data-fragment-index="2"><span class="when">post-1980s</span><strong>Its own structure.</strong> The field stops mimicking microelectronics and develops a shape of its own, but the core concept was already established: many components on a single substrate.</li>
+      <li class="fragment" data-fragment-index="3"><span class="when">today</span><strong>Guided waves plus all associated disciplines.</strong> Electro-optics, acousto-optics, nonlinear optics, and opto-electronics, together on one substrate.</li>
+    </ol>
+    <svg class="fig" viewBox="0 0 400 260" role="img" aria-labelledby="h-title h-desc">
+      <title id="h-title">Microelectronic chip beside a photonic chip</title>
+      <desc id="h-desc">Left: a chip with transistors joined by metal traces. Right: a chip with photonic blocks joined by waveguides. The layouts mirror each other.</desc>
+      <g class="fragment" data-fragment-index="1">
+        <text x="10" y="20" class="tiny">microelectronics</text>
+        <rect class="chip" x="10" y="30" width="180" height="200" rx="8"/>
+        <g class="elec" style="stroke-width:1.5;opacity:0.8">
+          <path d="M30 70 H90 V130 H150"/><path d="M30 130 H60 V190 H150"/><path d="M90 70 V50 H150"/>
+        </g>
+        <rect class="box" x="26" y="60" width="16" height="20" style="stroke:var(--code)"/>
+        <rect class="box" x="82" y="120" width="16" height="20" style="stroke:var(--code)"/>
+        <rect class="box" x="52" y="180" width="16" height="20" style="stroke:var(--code)"/>
+        <rect class="box" x="142" y="40" width="16" height="20" style="stroke:var(--code)"/>
+        <text x="30" y="222" class="tiny" style="fill:var(--code)">transistors + metal</text>
+      </g>
+      <g class="fragment" data-fragment-index="2">
+        <text x="210" y="20" class="tiny">integrated photonics</text>
+        <rect class="chip" x="210" y="30" width="180" height="200" rx="8"/>
+        <g class="beam" style="stroke-width:1.5;opacity:0.85">
+          <path class="draw" style="--len:260;--dur:1200ms" d="M230 70 H290 C300 70 300 130 310 130 H350"/>
+          <path class="draw" style="--len:260;--dur:1200ms;--delay:200ms" d="M230 130 H260 C270 130 270 190 280 190 H350"/>
+          <path class="draw" style="--len:260;--dur:1200ms;--delay:400ms" d="M290 70 C290 50 300 50 350 50"/>
+        </g>
+        <rect class="box acc" x="226" y="60" width="16" height="20"/>
+        <rect class="box acc" x="282" y="120" width="16" height="20"/>
+        <rect class="box acc" x="252" y="180" width="16" height="20"/>
+        <rect class="box acc" x="342" y="40" width="16" height="20"/>
+        <text x="236" y="222" class="tiny acc">components + waveguides</text>
+      </g>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 17 · Table to chip (auto-animate pair) ═══════════════════════════════ -->
+<section data-auto-animate data-auto-animate-id="bench">
+  <p class="eyebrow"><span class="num">[ 16 ]</span><span class="sep">|</span>the one design move</p>
+  <h2>On the table, light travels in free space</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>On an optical table there is no guiding mechanism. The sources are coherent, the beams barely diverge, and you can manage the alignment by hand. No waveguides anywhere.</p>
+      <p class="muted small">Press the right arrow.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 520 240" role="img" aria-labelledby="w1-title w1-desc">
+      <title id="w1-title">Discrete components spread across an optical table</title>
+      <desc id="w1-desc">Four components sit far apart on a table with a free-space beam threading between them.</desc>
+      <rect data-id="bench" class="chip" x="10" y="20" width="500" height="200" rx="6" style="stroke:var(--strong)"/>
+      <path data-id="beam" class="beam" d="M40 120 H130 L250 60 L370 160 H480" style="opacity:0.9"/>
+      <rect data-id="c1" class="box acc" x="30" y="100" width="40" height="40" rx="4"/>
+      <rect data-id="c2" class="box" x="110" y="100" width="40" height="40" rx="4"/>
+      <rect data-id="c3" class="box" x="230" y="40" width="40" height="40" rx="4"/>
+      <rect data-id="c4" class="box" x="350" y="140" width="40" height="40" rx="4"/>
+      <rect data-id="c5" class="box" x="460" y="100" width="40" height="40" rx="4"/>
+      <text data-id="cap" x="200" y="210" class="tiny">free space, coherent source, hand alignment</text>
+    </svg>
+  </div>
+</section>
+
+<section data-auto-animate data-auto-animate-id="bench">
+  <p class="eyebrow"><span class="num">[ 16 ]</span><span class="sep">|</span>the one design move</p>
+  <h2>On the chip, light has to be guided</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>Put the circuit on a substrate and every component must be <strong>connected</strong>. Light has to be <strong>guided</strong> from one block to the next. The waveguide is the backbone of integrated photonics.</p>
+      <p class="muted small">Guided-wave technology is what the 1960s proposal added to the microelectronics analogy.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 520 240" role="img" aria-labelledby="w2-title w2-desc">
+      <title id="w2-title">The same components collapsed onto a chip and joined by a waveguide</title>
+      <desc id="w2-desc">The five blocks sit in a line on a small chip and a waveguide runs through all of them.</desc>
+      <rect data-id="bench" class="chip" x="60" y="70" width="400" height="100" rx="8"/>
+      <path class="guide" d="M60 114 H460 V126 H60 Z"/>
+      <path data-id="beam" class="beam flowing" d="M60 120 H460"/>
+      <rect data-id="c1" class="box acc" x="80" y="100" width="40" height="40" rx="4"/>
+      <rect data-id="c2" class="box" x="160" y="100" width="40" height="40" rx="4"/>
+      <rect data-id="c3" class="box" x="240" y="100" width="40" height="40" rx="4"/>
+      <rect data-id="c4" class="box" x="320" y="100" width="40" height="40" rx="4"/>
+      <rect data-id="c5" class="box" x="400" y="100" width="40" height="40" rx="4"/>
+      <text data-id="cap" x="150" y="200" class="tiny acc">guided wave on a planar substrate</text>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 18 · Definition assembled ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 17 ]</span><span class="sep">|</span>putting it together</p>
+  <h2>Integrated photonics, defined</h2>
+  <div class="cols wide-fig">
+    <div class="stack">
+      <p>Combine <strong>guided-wave technology</strong> with all of the associated disciplines, on a <strong>single substrate</strong>.</p>
+      <p class="fragment small" data-fragment-index="5">Note what the definition does <em>not</em> say: nothing about a particular material system. It is a philosophy of bringing components and functionalities onto one substrate through a guided-wave mechanism.</p>
+    </div>
+    <svg class="fig" viewBox="0 0 480 300" role="img" aria-labelledby="z-title z-desc">
+      <title id="z-title">Disciplines stacked on a substrate, joined by a waveguide</title>
+      <desc id="z-desc">A substrate at the bottom. Four labelled blocks (electro-optics, acousto-optics, nonlinear optics, opto-electronics) sit on it, and a waveguide runs through all of them.</desc>
+      <rect class="chip" x="10" y="200" width="460" height="60" rx="8"/>
+      <text x="28" y="236" class="lbl">single substrate (any material)</text>
+      <path class="guide" d="M10 150 H470 V162 H10 Z"/>
+      <path class="beam flowing" d="M10 156 H470"/>
+      <g class="fragment" data-fragment-index="1"><rect class="box acc" x="30" y="90" width="96" height="100" rx="6"/><text x="40" y="120" class="tiny">electro-</text><text x="40" y="136" class="tiny">optics</text></g>
+      <g class="fragment" data-fragment-index="2"><rect class="box acc" x="136" y="90" width="96" height="100" rx="6"/><text x="146" y="120" class="tiny">acousto-</text><text x="146" y="136" class="tiny">optics</text></g>
+      <g class="fragment" data-fragment-index="3"><rect class="box acc" x="242" y="90" width="96" height="100" rx="6"/><text x="252" y="120" class="tiny">nonlinear</text><text x="252" y="136" class="tiny">optics</text></g>
+      <g class="fragment" data-fragment-index="4"><rect class="box acc" x="348" y="90" width="96" height="100" rx="6"/><text x="358" y="120" class="tiny">opto-</text><text x="358" y="136" class="tiny">electronics</text></g>
+      <text x="30" y="60" class="lbl fragment" data-fragment-index="4">functionalities connected and guided through one another</text>
+    </svg>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 19 · Check your understanding ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">[ 18 ]</span><span class="sep">|</span>check your understanding</p>
+  <h2>Three questions before the next lecture</h2>
+  <ol>
+    <li class="fragment" data-fragment-index="1">A splitter, a grating, and a coupler sit on the same substrate but nothing connects them. Is that integrated photonics? What is missing from the definition?</li>
+    <li class="fragment" data-fragment-index="2">Silicon has an indirect band gap. Which on-chip roles can it fill well, and which one is hard? Why did compound semiconductors matter so much?</li>
+    <li class="fragment" data-fragment-index="3">Electro-optics and acousto-optics both control light with an external signal. Name the control knob in each, and the physical thing in the material that the light actually responds to.</li>
+  </ol>
+  <div class="card fragment" data-fragment-index="4" style="margin-top:14px">
+    <span class="k">what to remember</span>
+    Integrated photonics is <strong>components with individual functionalities, connected by guided waves, on one planar substrate</strong>. The laser, the semiconductor optical device, and low-loss fiber made photonics; the 1960s microelectronics analogy made it a circuit.
+  </div>
+</section>
+
+<!-- ═══════════════════════════════ 20 · End ═══════════════════════════════ -->
+<section>
+  <p class="eyebrow"><span class="num">photonics</span><span class="sep">|</span>photonic integrated circuits<span class="sep">|</span>deck 01 of the series</p>
+  <h2>Next: how the components themselves evolved</h2>
+  <p>The following lecture takes the historic perspective of the individual components, and how each evolved, before the series dives into the real physics.</p>
+  <p class="small muted" style="margin-top:1.6em">Adapted from NPTEL, <a href="https://www.youtube.com/watch?v=MOKPFINLPXE">Lec 05: Photonic integrated circuits, an introduction</a>. Diagrams and the interferometer demo are original; the ordering and framing follow the lecture.</p>
+  <p class="small muted"><a href="../../../slides/photonic-integrated-circuits/">Back to the series</a> <span style="color:var(--strong)">|</span> <a href="../../../slides/">All slides</a></p>
+</section>
+
+</div>
+</div>
+
+<div class="deck-label"><a href="../../../">~/sk</a><span class="sep">|</span><a href="../../../slides/">slides</a><span class="sep">|</span>photonic integrated circuits 01</div>
+
+<script src="https://cdn.jsdelivr.net/npm/reveal.js@6.0.1/dist/reveal.js"></script>
+<script>
+(function () {
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  Reveal.initialize({
+    hash: true,
+    controls: true,
+    controlsTutorial: false,
+    progress: true,
+    slideNumber: 'c/t',
+    center: false,
+    width: 1180,
+    height: 700,
+    margin: 0.06,
+    transition: reduce ? 'none' : 'fade',
+    transitionSpeed: 'fast',
+    backgroundTransition: 'none',
+    autoAnimateDuration: reduce ? 0 : 0.8,
+    autoAnimateEasing: 'ease-in-out',
+    fragmentInURL: true,
+    navigationMode: 'linear',
+    keyboardCondition: function (event) {
+      // Let the range slider own its own arrow keys.
+      return !(event.target && event.target.tagName === 'INPUT');
+    }
+  });
+
+  // Mach-Zehnder demo: I = cos^2(phi / 2).
+  var phase = document.getElementById('mzi-phase');
+  if (phase) {
+    var out = document.getElementById('mzi-out');
+    var iOut = document.getElementById('mzi-i');
+    var fill = document.getElementById('mzi-fill');
+    var beam = document.getElementById('mzi-outbeam');
+    var det = document.getElementById('mzi-det');
+    var marker = document.getElementById('mzi-marker');
+    var phi = document.getElementById('mzi-phi');
+    function update() {
+      var deg = Number(phase.value);
+      var rad = deg * Math.PI / 180;
+      var I = Math.cos(rad / 2) * Math.cos(rad / 2);
+      out.textContent = deg + '°';
+      iOut.textContent = I.toFixed(2);
+      fill.style.width = (I * 100).toFixed(1) + '%';
+      beam.style.opacity = String(0.08 + 0.92 * I);
+      beam.style.strokeWidth = String(1 + 2.5 * I);
+      det.style.opacity = String(0.15 + 0.85 * I);
+      phi.textContent = 'phi=' + deg;
+      // marker rides the fringe sketch: x from 0..80 over 0..360, y = 40 - 30 * I
+      marker.setAttribute('cx', String(deg / 360 * 80));
+      marker.setAttribute('cy', String(40 - 30 * I));
+    }
+    phase.addEventListener('input', update);
+    update();
+  }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Introduces a new Slides section to the site with a reveal.js-based deck system and the first deck series on photonic integrated circuits. This adds a new content format alongside the existing blog, enabling interactive visual explanations with animated SVG diagrams and stepwise reveals.

## Key Changes

- **New slides infrastructure**: Created `site/app/slides/` with registry (`decks.ts`), index page, and folder page template for organizing decks into series
- **Deck system documentation**: Added `.agent/slides-system.md` governing deck structure, content rules, visual rules, and the reveal.js animation grammar
- **First deck series**: Implemented "Photonic integrated circuits" folder with deck 01 (introduction), a 21-slide reveal.js presentation with:
  - Custom CSS styling using site design tokens (dark theme, typography, color palette)
  - Animated SVG diagrams (waveguides, light propagation, component schematics)
  - Interactive Mach-Zehnder interferometer demo with phase slider
  - Fragment-driven reveals synchronized with diagrams
  - Consistent eyebrow/bracket numbering and visual hierarchy
- **Navigation integration**: Added "slides" nav item to `Nav.tsx` alongside home and blog
- **Site config helper**: Added `deckUrl()` utility in `site/lib/site-config.ts` to handle `basePath` prefixing for static deck links
- **Updated AGENTS.md**: Documented the new slides system as a binding reference

## Implementation Details

- Decks live under `site/public/slides/` as self-contained static HTML files (not processed by Next.js), allowing offline use and easy copying
- Deck styling mirrors site tokens but is scoped locally to avoid conflicts with `globals.css` reading-column constraints
- SVG figures use a consistent class-based grammar (`.beam`, `.guide`, `.box`, `.dot`, etc.) with CSS animations (dash-travel, flow, pulse-along, blink)
- Fragment reveals use `data-fragment-index` to synchronize text and diagram steps
- Reduced-motion media query ensures animations resolve to final state for accessibility
- Decks are registered in a type-safe registry (`Deck`, `DeckFolder`, `StandaloneDeck`) mirroring the book/chapter pattern

https://claude.ai/code/session_014ujCELk1Vwhfhpr6zV1GNZ